### PR TITLE
fix: scoring answers with negative scores

### DIFF
--- a/packages/mastering/__tests__/__snapshots__/testExamMastering.ts.snap
+++ b/packages/mastering/__tests__/__snapshots__/testExamMastering.ts.snap
@@ -3275,13 +3275,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "14.1",
-        "id": 47,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "14.2",
             "id": 15,
@@ -3309,13 +3302,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "14.2",
-        "id": 48,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "14.3",
             "id": 16,
@@ -3344,8 +3330,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "14.3",
-        "id": 49,
+        "displayNumber": "14",
+        "id": 47,
         "type": "choicegroup",
       },
     ],
@@ -3602,13 +3588,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "14.1",
-        "id": 47,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "14.2",
             "id": 15,
@@ -3636,13 +3615,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "14.2",
-        "id": 48,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "14.3",
             "id": 16,
@@ -3671,8 +3643,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "14.3",
-        "id": 49,
+        "displayNumber": "14",
+        "id": 47,
         "type": "choicegroup",
       },
     ],
@@ -9883,13 +9855,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.1",
-        "id": 88,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.2",
             "id": 2,
@@ -9917,13 +9882,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.2",
-        "id": 89,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.3",
             "id": 3,
@@ -9951,13 +9909,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.3",
-        "id": 90,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.4",
             "id": 4,
@@ -9985,13 +9936,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.4",
-        "id": 91,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.5",
             "id": 5,
@@ -10019,13 +9963,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.5",
-        "id": 92,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.6",
             "id": 6,
@@ -10054,8 +9991,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "1.6",
-        "id": 93,
+        "displayNumber": "1",
+        "id": 88,
         "type": "choicegroup",
       },
       Object {
@@ -10092,19 +10029,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.1",
-        "id": 94,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "2.2",
-        "id": 8,
-        "maxScore": 1,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.3",
             "id": 9,
@@ -10137,19 +10061,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.3",
-        "id": 95,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "2.4",
-        "id": 10,
-        "maxScore": 1,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.5",
             "id": 11,
@@ -10182,19 +10093,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.5",
-        "id": 96,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "2.6",
-        "id": 12,
-        "maxScore": 1,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.7",
             "id": 13,
@@ -10227,19 +10125,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.7",
-        "id": 97,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "2.8",
-        "id": 14,
-        "maxScore": 1,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.9",
             "id": 15,
@@ -10272,19 +10157,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.9",
-        "id": 98,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "2.10",
-        "id": 16,
-        "maxScore": 1,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.11",
             "id": 17,
@@ -10318,9 +10190,39 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "2.11",
-        "id": 99,
+        "displayNumber": "2",
+        "id": 89,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "2.2",
+        "id": 8,
+        "maxScore": 1,
+        "type": "text",
+      },
+      Object {
+        "displayNumber": "2.4",
+        "id": 10,
+        "maxScore": 1,
+        "type": "text",
+      },
+      Object {
+        "displayNumber": "2.6",
+        "id": 12,
+        "maxScore": 1,
+        "type": "text",
+      },
+      Object {
+        "displayNumber": "2.8",
+        "id": 14,
+        "maxScore": 1,
+        "type": "text",
+      },
+      Object {
+        "displayNumber": "2.10",
+        "id": 16,
+        "maxScore": 1,
+        "type": "text",
       },
       Object {
         "displayNumber": "2.12",
@@ -10520,13 +10422,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.1",
-        "id": 88,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.2",
             "id": 2,
@@ -10554,13 +10449,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.2",
-        "id": 89,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.3",
             "id": 3,
@@ -10588,13 +10476,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.3",
-        "id": 90,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.4",
             "id": 4,
@@ -10622,13 +10503,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.4",
-        "id": 91,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.5",
             "id": 5,
@@ -10656,13 +10530,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.5",
-        "id": 92,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.6",
             "id": 6,
@@ -10691,8 +10558,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "1.6",
-        "id": 93,
+        "displayNumber": "1",
+        "id": 88,
         "type": "choicegroup",
       },
       Object {
@@ -10729,19 +10596,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.1",
-        "id": 94,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "2.2",
-        "id": 8,
-        "maxScore": 1,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.3",
             "id": 9,
@@ -10774,19 +10628,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.3",
-        "id": 95,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "2.4",
-        "id": 10,
-        "maxScore": 1,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.5",
             "id": 11,
@@ -10819,19 +10660,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.5",
-        "id": 96,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "2.6",
-        "id": 12,
-        "maxScore": 1,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.7",
             "id": 13,
@@ -10864,19 +10692,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.7",
-        "id": 97,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "2.8",
-        "id": 14,
-        "maxScore": 1,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.9",
             "id": 15,
@@ -10909,19 +10724,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.9",
-        "id": 98,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "2.10",
-        "id": 16,
-        "maxScore": 1,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.11",
             "id": 17,
@@ -10955,9 +10757,39 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "2.11",
-        "id": 99,
+        "displayNumber": "2",
+        "id": 89,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "2.2",
+        "id": 8,
+        "maxScore": 1,
+        "type": "text",
+      },
+      Object {
+        "displayNumber": "2.4",
+        "id": 10,
+        "maxScore": 1,
+        "type": "text",
+      },
+      Object {
+        "displayNumber": "2.6",
+        "id": 12,
+        "maxScore": 1,
+        "type": "text",
+      },
+      Object {
+        "displayNumber": "2.8",
+        "id": 14,
+        "maxScore": 1,
+        "type": "text",
+      },
+      Object {
+        "displayNumber": "2.10",
+        "id": 16,
+        "maxScore": 1,
+        "type": "text",
       },
       Object {
         "displayNumber": "2.12",
@@ -13006,19 +12838,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.1",
-        "id": 330,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "1.2",
-        "id": 2,
-        "maxScore": 6,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.3",
             "id": 3,
@@ -13041,13 +12860,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.3",
-        "id": 331,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.4",
             "id": 4,
@@ -13071,9 +12883,15 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "1.4",
-        "id": 332,
+        "displayNumber": "1",
+        "id": 328,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "1.2",
+        "id": 2,
+        "maxScore": 6,
+        "type": "text",
       },
       Object {
         "displayNumber": "1.5",
@@ -13105,13 +12923,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.1",
-        "id": 333,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.2",
             "id": 7,
@@ -13134,13 +12945,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.2",
-        "id": 334,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.3",
             "id": 8,
@@ -13163,13 +12967,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.3",
-        "id": 335,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.4",
             "id": 9,
@@ -13193,8 +12990,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "2.4",
-        "id": 336,
+        "displayNumber": "2",
+        "id": 329,
         "type": "choicegroup",
       },
       Object {
@@ -13221,13 +13018,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "3.1",
-        "id": 337,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "3.2",
             "id": 11,
@@ -13250,13 +13040,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "3.2",
-        "id": 338,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "3.3",
             "id": 12,
@@ -13279,13 +13062,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "3.3",
-        "id": 339,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "3.4",
             "id": 13,
@@ -13308,13 +13084,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "3.4",
-        "id": 340,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "3.5",
             "id": 14,
@@ -13338,8 +13107,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "3.5",
-        "id": 341,
+        "displayNumber": "3",
+        "id": 330,
         "type": "choicegroup",
       },
       Object {
@@ -13366,13 +13135,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "4.1",
-        "id": 342,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "4.2",
             "id": 16,
@@ -13396,15 +13158,9 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "4.2",
-        "id": 343,
+        "displayNumber": "4",
+        "id": 331,
         "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "5.1",
-        "id": 17,
-        "maxScore": 3,
-        "type": "text",
       },
       Object {
         "choices": Array [
@@ -13430,13 +13186,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "5.2",
-        "id": 344,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "5.3",
             "id": 19,
@@ -13460,9 +13209,15 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "5.3",
-        "id": 345,
+        "displayNumber": "5",
+        "id": 332,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "5.1",
+        "id": 17,
+        "maxScore": 3,
+        "type": "text",
       },
       Object {
         "choices": Array [
@@ -13513,13 +13268,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "6.1",
-        "id": 346,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "6.2",
             "id": 21,
@@ -13567,13 +13315,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "6.2",
-        "id": 347,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "6.3",
             "id": 22,
@@ -13622,8 +13363,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "6.3",
-        "id": 348,
+        "displayNumber": "6",
+        "id": 333,
         "type": "choicegroup",
       },
       Object {
@@ -13650,13 +13391,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "7.1",
-        "id": 349,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "7.2",
             "id": 24,
@@ -13679,13 +13413,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "7.2",
-        "id": 350,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "7.3",
             "id": 25,
@@ -13709,8 +13436,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "7.3",
-        "id": 351,
+        "displayNumber": "7",
+        "id": 334,
         "type": "choicegroup",
       },
       Object {
@@ -13737,13 +13464,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "8.1",
-        "id": 352,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "8.2",
             "id": 27,
@@ -13767,8 +13487,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "8.2",
-        "id": 353,
+        "displayNumber": "8",
+        "id": 335,
         "type": "choicegroup",
       },
       Object {
@@ -13790,13 +13510,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "9.1",
-        "id": 354,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "9.2",
             "id": 29,
@@ -13814,13 +13527,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "9.2",
-        "id": 355,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "9.3",
             "id": 30,
@@ -13838,13 +13544,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "9.3",
-        "id": 356,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "9.4",
             "id": 31,
@@ -13862,13 +13561,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "9.4",
-        "id": 357,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "9.5",
             "id": 32,
@@ -13886,13 +13578,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "9.5",
-        "id": 358,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "9.6",
             "id": 33,
@@ -13911,8 +13596,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "9.6",
-        "id": 359,
+        "displayNumber": "9",
+        "id": 336,
         "type": "choicegroup",
       },
       Object {
@@ -13939,19 +13624,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "10.1",
-        "id": 360,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "10.2",
-        "id": 35,
-        "maxScore": 6,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "10.3",
             "id": 36,
@@ -13974,13 +13646,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "10.3",
-        "id": 361,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "10.4",
             "id": 37,
@@ -14004,9 +13669,15 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "10.4",
-        "id": 362,
+        "displayNumber": "10",
+        "id": 337,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "10.2",
+        "id": 35,
+        "maxScore": 6,
+        "type": "text",
       },
       Object {
         "choices": Array [
@@ -14032,25 +13703,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "11.1",
-        "id": 363,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "11.2.1",
-        "id": 39,
-        "maxScore": 3,
-        "type": "text",
-      },
-      Object {
-        "displayNumber": "11.2.2",
-        "id": 40,
-        "maxScore": 3,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "11.3",
             "id": 41,
@@ -14073,13 +13725,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "11.3",
-        "id": 364,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "11.4",
             "id": 42,
@@ -14102,13 +13747,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "11.4",
-        "id": 365,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "11.5",
             "id": 43,
@@ -14131,13 +13769,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "11.5",
-        "id": 366,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "11.6",
             "id": 44,
@@ -14161,9 +13792,21 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "11.6",
-        "id": 367,
+        "displayNumber": "11",
+        "id": 338,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "11.2.1",
+        "id": 39,
+        "maxScore": 3,
+        "type": "text",
+      },
+      Object {
+        "displayNumber": "11.2.2",
+        "id": 40,
+        "maxScore": 3,
+        "type": "text",
       },
       Object {
         "choices": Array [
@@ -14325,7 +13968,7 @@ Object {
           },
         ],
         "displayNumber": "12",
-        "id": 328,
+        "id": 339,
         "type": "choicegroup",
       },
       Object {
@@ -14352,13 +13995,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "13.1",
-        "id": 368,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "13.2",
             "id": 49,
@@ -14382,8 +14018,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "13.2",
-        "id": 369,
+        "displayNumber": "13",
+        "id": 340,
         "type": "choicegroup",
       },
       Object {
@@ -14416,19 +14052,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "14.1",
-        "id": 370,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "14.2",
-        "id": 52,
-        "maxScore": 4,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "14.3",
             "id": 53,
@@ -14451,13 +14074,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "14.3",
-        "id": 371,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "14.4",
             "id": 54,
@@ -14481,13 +14097,13 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "14.4",
-        "id": 372,
+        "displayNumber": "14",
+        "id": 341,
         "type": "choicegroup",
       },
       Object {
-        "displayNumber": "15.1",
-        "id": 55,
+        "displayNumber": "14.2",
+        "id": 52,
         "maxScore": 4,
         "type": "text",
       },
@@ -14515,13 +14131,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "15.2",
-        "id": 373,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "15.3",
             "id": 57,
@@ -14544,13 +14153,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "15.3",
-        "id": 374,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "15.4",
             "id": 58,
@@ -14573,13 +14175,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "15.4",
-        "id": 375,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "15.5",
             "id": 59,
@@ -14602,13 +14197,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "15.5",
-        "id": 376,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "15.6",
             "id": 60,
@@ -14632,9 +14220,15 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "15.6",
-        "id": 377,
+        "displayNumber": "15",
+        "id": 342,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "15.1",
+        "id": 55,
+        "maxScore": 4,
+        "type": "text",
       },
       Object {
         "choices": Array [
@@ -14660,13 +14254,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "16.1",
-        "id": 378,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "16.2",
             "id": 62,
@@ -14689,13 +14276,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "16.2",
-        "id": 379,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "16.3",
             "id": 63,
@@ -14719,8 +14299,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "16.3",
-        "id": 380,
+        "displayNumber": "16",
+        "id": 343,
         "type": "choicegroup",
       },
       Object {
@@ -15085,7 +14665,7 @@ Object {
           },
         ],
         "displayNumber": "17",
-        "id": 329,
+        "id": 344,
         "type": "choicegroup",
       },
       Object {
@@ -15337,19 +14917,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.1",
-        "id": 330,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "1.2",
-        "id": 2,
-        "maxScore": 6,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.3",
             "id": 3,
@@ -15372,13 +14939,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "1.3",
-        "id": 331,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "1.4",
             "id": 4,
@@ -15402,9 +14962,15 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "1.4",
-        "id": 332,
+        "displayNumber": "1",
+        "id": 328,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "1.2",
+        "id": 2,
+        "maxScore": 6,
+        "type": "text",
       },
       Object {
         "displayNumber": "1.5",
@@ -15436,13 +15002,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.1",
-        "id": 333,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.2",
             "id": 7,
@@ -15465,13 +15024,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.2",
-        "id": 334,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.3",
             "id": 8,
@@ -15494,13 +15046,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "2.3",
-        "id": 335,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "2.4",
             "id": 9,
@@ -15524,8 +15069,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "2.4",
-        "id": 336,
+        "displayNumber": "2",
+        "id": 329,
         "type": "choicegroup",
       },
       Object {
@@ -15552,13 +15097,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "3.1",
-        "id": 337,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "3.2",
             "id": 11,
@@ -15581,13 +15119,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "3.2",
-        "id": 338,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "3.3",
             "id": 12,
@@ -15610,13 +15141,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "3.3",
-        "id": 339,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "3.4",
             "id": 13,
@@ -15639,13 +15163,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "3.4",
-        "id": 340,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "3.5",
             "id": 14,
@@ -15669,8 +15186,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "3.5",
-        "id": 341,
+        "displayNumber": "3",
+        "id": 330,
         "type": "choicegroup",
       },
       Object {
@@ -15697,13 +15214,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "4.1",
-        "id": 342,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "4.2",
             "id": 16,
@@ -15727,15 +15237,9 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "4.2",
-        "id": 343,
+        "displayNumber": "4",
+        "id": 331,
         "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "5.1",
-        "id": 17,
-        "maxScore": 3,
-        "type": "text",
       },
       Object {
         "choices": Array [
@@ -15761,13 +15265,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "5.2",
-        "id": 344,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "5.3",
             "id": 19,
@@ -15791,9 +15288,15 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "5.3",
-        "id": 345,
+        "displayNumber": "5",
+        "id": 332,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "5.1",
+        "id": 17,
+        "maxScore": 3,
+        "type": "text",
       },
       Object {
         "choices": Array [
@@ -15844,13 +15347,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "6.1",
-        "id": 346,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "6.2",
             "id": 21,
@@ -15898,13 +15394,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "6.2",
-        "id": 347,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "6.3",
             "id": 22,
@@ -15953,8 +15442,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "6.3",
-        "id": 348,
+        "displayNumber": "6",
+        "id": 333,
         "type": "choicegroup",
       },
       Object {
@@ -15981,13 +15470,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "7.1",
-        "id": 349,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "7.2",
             "id": 24,
@@ -16010,13 +15492,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "7.2",
-        "id": 350,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "7.3",
             "id": 25,
@@ -16040,8 +15515,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "7.3",
-        "id": 351,
+        "displayNumber": "7",
+        "id": 334,
         "type": "choicegroup",
       },
       Object {
@@ -16068,13 +15543,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "8.1",
-        "id": 352,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "8.2",
             "id": 27,
@@ -16098,8 +15566,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "8.2",
-        "id": 353,
+        "displayNumber": "8",
+        "id": 335,
         "type": "choicegroup",
       },
       Object {
@@ -16121,13 +15589,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "9.1",
-        "id": 354,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "9.2",
             "id": 29,
@@ -16145,13 +15606,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "9.2",
-        "id": 355,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "9.3",
             "id": 30,
@@ -16169,13 +15623,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "9.3",
-        "id": 356,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "9.4",
             "id": 31,
@@ -16193,13 +15640,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "9.4",
-        "id": 357,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "9.5",
             "id": 32,
@@ -16217,13 +15657,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "9.5",
-        "id": 358,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "9.6",
             "id": 33,
@@ -16242,8 +15675,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "9.6",
-        "id": 359,
+        "displayNumber": "9",
+        "id": 336,
         "type": "choicegroup",
       },
       Object {
@@ -16270,19 +15703,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "10.1",
-        "id": 360,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "10.2",
-        "id": 35,
-        "maxScore": 6,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "10.3",
             "id": 36,
@@ -16305,13 +15725,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "10.3",
-        "id": 361,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "10.4",
             "id": 37,
@@ -16335,9 +15748,15 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "10.4",
-        "id": 362,
+        "displayNumber": "10",
+        "id": 337,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "10.2",
+        "id": 35,
+        "maxScore": 6,
+        "type": "text",
       },
       Object {
         "choices": Array [
@@ -16363,25 +15782,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "11.1",
-        "id": 363,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "11.2.1",
-        "id": 39,
-        "maxScore": 3,
-        "type": "text",
-      },
-      Object {
-        "displayNumber": "11.2.2",
-        "id": 40,
-        "maxScore": 3,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "11.3",
             "id": 41,
@@ -16404,13 +15804,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "11.3",
-        "id": 364,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "11.4",
             "id": 42,
@@ -16433,13 +15826,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "11.4",
-        "id": 365,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "11.5",
             "id": 43,
@@ -16462,13 +15848,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "11.5",
-        "id": 366,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "11.6",
             "id": 44,
@@ -16492,9 +15871,21 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "11.6",
-        "id": 367,
+        "displayNumber": "11",
+        "id": 338,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "11.2.1",
+        "id": 39,
+        "maxScore": 3,
+        "type": "text",
+      },
+      Object {
+        "displayNumber": "11.2.2",
+        "id": 40,
+        "maxScore": 3,
+        "type": "text",
       },
       Object {
         "choices": Array [
@@ -16656,7 +16047,7 @@ Object {
           },
         ],
         "displayNumber": "12",
-        "id": 328,
+        "id": 339,
         "type": "choicegroup",
       },
       Object {
@@ -16683,13 +16074,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "13.1",
-        "id": 368,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "13.2",
             "id": 49,
@@ -16713,8 +16097,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "13.2",
-        "id": 369,
+        "displayNumber": "13",
+        "id": 340,
         "type": "choicegroup",
       },
       Object {
@@ -16747,19 +16131,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "14.1",
-        "id": 370,
-        "type": "choicegroup",
-      },
-      Object {
-        "displayNumber": "14.2",
-        "id": 52,
-        "maxScore": 4,
-        "type": "text",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "14.3",
             "id": 53,
@@ -16782,13 +16153,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "14.3",
-        "id": 371,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "14.4",
             "id": 54,
@@ -16812,13 +16176,13 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "14.4",
-        "id": 372,
+        "displayNumber": "14",
+        "id": 341,
         "type": "choicegroup",
       },
       Object {
-        "displayNumber": "15.1",
-        "id": 55,
+        "displayNumber": "14.2",
+        "id": 52,
         "maxScore": 4,
         "type": "text",
       },
@@ -16846,13 +16210,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "15.2",
-        "id": 373,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "15.3",
             "id": 57,
@@ -16875,13 +16232,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "15.3",
-        "id": 374,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "15.4",
             "id": 58,
@@ -16904,13 +16254,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "15.4",
-        "id": 375,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "15.5",
             "id": 59,
@@ -16933,13 +16276,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "15.5",
-        "id": 376,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "15.6",
             "id": 60,
@@ -16963,9 +16299,15 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "15.6",
-        "id": 377,
+        "displayNumber": "15",
+        "id": 342,
         "type": "choicegroup",
+      },
+      Object {
+        "displayNumber": "15.1",
+        "id": 55,
+        "maxScore": 4,
+        "type": "text",
       },
       Object {
         "choices": Array [
@@ -16991,13 +16333,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "16.1",
-        "id": 378,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "16.2",
             "id": 62,
@@ -17020,13 +16355,6 @@ Object {
             ],
             "type": "choice",
           },
-        ],
-        "displayNumber": "16.2",
-        "id": 379,
-        "type": "choicegroup",
-      },
-      Object {
-        "choices": Array [
           Object {
             "displayNumber": "16.3",
             "id": 63,
@@ -17050,8 +16378,8 @@ Object {
             "type": "choice",
           },
         ],
-        "displayNumber": "16.3",
-        "id": 380,
+        "displayNumber": "16",
+        "id": 343,
         "type": "choicegroup",
       },
       Object {
@@ -17416,7 +16744,7 @@ Object {
           },
         ],
         "displayNumber": "17",
-        "id": 329,
+        "id": 344,
         "type": "choicegroup",
       },
       Object {


### PR DESCRIPTION
Group all choice-answer and dropdown-answers within a top-level question
to the same choicegroup. This way you may not get negative scores from a
top level question.