### PR TITLE
Fix: Show display number instead of question id in save errors

### DIFF
--- a/packages/core/src/components/ChoiceAnswer.tsx
+++ b/packages/core/src/components/ChoiceAnswer.tsx
@@ -79,8 +79,9 @@ function ChoiceAnswer({ answer, saveAnswer, element, renderChildNodes }: ChoiceA
   const questionId = getNumericAttribute(element, 'question-id')!
   const direction = element.getAttribute('direction') || 'vertical'
   const className = element.getAttribute('class')
+  const displayNumber = element.getAttribute('display-number')!
   const onSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
-    saveAnswer({ type: 'choice', questionId, value: event.currentTarget.value })
+    saveAnswer({ type: 'choice', questionId, value: event.currentTarget.value, displayNumber })
   }
 
   return (

--- a/packages/core/src/components/DropdownAnswer.tsx
+++ b/packages/core/src/components/DropdownAnswer.tsx
@@ -25,6 +25,7 @@ type Item = Element | typeof noAnswer
 
 function DropdownAnswer({ element, renderChildNodes, saveAnswer, answer }: DropdownAnswerProps) {
   const questionId = getNumericAttribute(element, 'question-id')!
+  const displayNumber = element.getAttribute('display-number')!
   const currentlySelectedItem =
     answer &&
     answer.value &&
@@ -32,7 +33,7 @@ function DropdownAnswer({ element, renderChildNodes, saveAnswer, answer }: Dropd
 
   const onChange = (selectedAnswer: '' | Element | null) => {
     const value = selectedAnswer ? selectedAnswer.getAttribute('option-id')! : ''
-    saveAnswer({ type: 'choice', questionId, value })
+    saveAnswer({ type: 'choice', questionId, value, displayNumber })
   }
 
   const labelRef = useRef<HTMLDivElement>(null)

--- a/packages/core/src/components/TextAnswer.tsx
+++ b/packages/core/src/components/TextAnswer.tsx
@@ -51,8 +51,15 @@ export class TextAnswer extends React.PureComponent<Props, State> {
   onChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { element, saveAnswer } = this.props
     const questionId = getNumericAttribute(element, 'question-id')!
+    const displayNumber = element.getAttribute('display-number')!
     const value = event.currentTarget.value
-    const answer: TextAnswerT = { type: 'text', questionId, value, characterCount: getCharacterCount(value) }
+    const answer: TextAnswerT = {
+      type: 'text',
+      questionId,
+      value,
+      characterCount: getCharacterCount(value),
+      displayNumber
+    }
     saveAnswer(answer)
     this.clearErrors()
   }
@@ -60,11 +67,13 @@ export class TextAnswer extends React.PureComponent<Props, State> {
   onRichTextChange = (answerHtml: string, answerText: string) => {
     const { element, saveAnswer } = this.props
     const questionId = getNumericAttribute(element, 'question-id')!
+    const displayNumber = element.getAttribute('display-number')!
     const answer: RichTextAnswerT = {
       type: 'richText',
       questionId,
       value: answerHtml,
-      characterCount: getCharacterCount(answerText)
+      characterCount: getCharacterCount(answerText),
+      displayNumber
     }
     saveAnswer(answer)
     this.clearErrors()

--- a/packages/core/src/components/types.ts
+++ b/packages/core/src/components/types.ts
@@ -6,6 +6,8 @@ export type QuestionId = number
 interface AnswerCommon {
   questionId: QuestionId
   value: string
+  /** This field is undefined in older exams that were packaged before this change. */
+  displayNumber?: string
 }
 export interface TextAnswer extends AnswerCommon {
   type: 'text'


### PR DESCRIPTION
This has been fixed for MEB exams already earlier, but XML exams show question id instead of display number.

![image](https://user-images.githubusercontent.com/6376268/72261504-a21d4480-361d-11ea-95cc-26c0b4b48b42.png)

PRs in:
- exam-engine, https://github.com/digabi/exam-engine/pull/127
- koe, https://github.com/digabi/koe/pull/69