### PR TITLE
Fix publish instructions to handle prereleases correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,23 @@ Travis CI runs tests on all branches and pull requests in https://travis-ci.org/
 
 ## NPM releases
 
-Login to npm first with digabi user and run
+First, login to npm using:
+
+```
+$ npm login
+```
+
+When publishing a prerelease, use:
+
+```
+$ env ANSWERS_PRIVATE_KEY=/absolute/path/to/answers-private-key.pem yarn lerna publish --dist-tag next
+```
+
+With official releases you need to skip the `dist-tag` parameter:
 
 ```
 $ env ANSWERS_PRIVATE_KEY=/absolute/path/to/answers-private-key.pem yarn lerna publish
 ```
+
+The commands prompt you for details about the release: just running them does not publish
+anything yet.


### PR DESCRIPTION
Without the `--dist-tag` parameter prereleases end up being installed for end users from the default latest tag.