### PR TITLE
Fix occasional issue with dropdown rendering

### DIFF
--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -13,6 +13,7 @@
     "css-loader": "^3.2.1",
     "dexie": "^2.0.4",
     "file-loader": "^5.0.2",
+    "html-inline-css-webpack-plugin": "^1.8.0",
     "html-webpack-plugin": "^3.2.0",
     "js-cookie": "^2.2.1",
     "less": "^3.10.3",

--- a/packages/rendering/public/offline.html
+++ b/packages/rendering/public/offline.html
@@ -3,11 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-
-    <link rel="preload" href="<%= htmlWebpackPlugin.options.scriptSrc %>" as="script" />
-    <link rel="preload" href="<%= htmlWebpackPlugin.options.styleSheetHref %>" as="style" />
-
-    <link rel="stylesheet" href="<%= htmlWebpackPlugin.options.styleSheetHref %>" />
     <script src="<%= htmlWebpackPlugin.options.scriptSrc %>" defer></script>
   </head>
   <body style="background-color: <%= htmlWebpackPlugin.options.backgroundColor %>;" />

--- a/packages/rendering/src/createOfflineExam.ts
+++ b/packages/rendering/src/createOfflineExam.ts
@@ -49,8 +49,15 @@ export async function createOfflineExam(examFile: string, outputDirectory: strin
       ]) {
         await page.goto('file://' + htmlFile, { waitUntil: 'networkidle0' })
         await page.evaluate(() => {
+          // Fix asset path on attachments page.
+          if (location.pathname.includes('attachments/index.html')) {
+            const style = document.head.querySelector(':scope > style')!
+            style.textContent = style.textContent!.replace(/url\(assets\//g, 'url(../assets/')
+          }
           // Remove rich-text-editor injected styles
-          document.head.querySelectorAll(':scope > style').forEach(e => e.remove())
+          Array.from(document.head.querySelectorAll(':scope > style'))
+            .filter(e => !e.textContent!.includes('NotoSans'))
+            .forEach(e => e.remove())
           // Remove rich-text-editor injected HTML.
           document.body.querySelectorAll(':scope > :not(main)').forEach(e => e.remove())
         })

--- a/packages/rendering/src/getOfflineWebpackConfig.ts
+++ b/packages/rendering/src/getOfflineWebpackConfig.ts
@@ -1,4 +1,5 @@
 import { MasteringResult } from '@digabi/exam-engine-mastering'
+import HTMLInlineCSSWebpackPlugin from 'html-inline-css-webpack-plugin'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
 import OptimizeCssAssetsPlugin from 'optimize-css-assets-webpack-plugin'
 import path from 'path'
@@ -27,17 +28,16 @@ export function getOfflineWebpackConfig(result: MasteringResult, outputDirectory
         template: path.resolve(__dirname, '../public/offline.html'),
         title: result.title!,
         backgroundColor: '#e0f4fe',
-        scriptSrc: 'main-bundle.js',
-        styleSheetHref: 'main.css'
+        scriptSrc: 'main-bundle.js'
       }),
       new HtmlWebpackPlugin({
         filename: 'attachments/index.html',
         template: path.resolve(__dirname, '../public/offline.html'),
         title: result.title!,
         backgroundColor: '#f0f0f0',
-        scriptSrc: '../main-bundle.js',
-        styleSheetHref: '../main.css'
-      })
+        scriptSrc: '../main-bundle.js'
+      }),
+      new HTMLInlineCSSWebpackPlugin()
     ]
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5084,6 +5084,13 @@ html-entities@^1.2.1:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
   integrity sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
 
+html-inline-css-webpack-plugin@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/html-inline-css-webpack-plugin/-/html-inline-css-webpack-plugin-1.8.0.tgz#f1120e08755658148b53f5596824fc5afece58ac"
+  integrity sha512-lNBoRA2Sl1+0VCUevElT/In208AtkvDFAMZN8K9bBkZ9gn+Ymi8vRCrKkSIF4MNVxdDL2x0LOGyDscQ7So9zcQ==
+  dependencies:
+    lodash "^4.17.15"
+
 html-minifier@^3.2.3:
   version "3.5.21"
   resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.21.tgz#d0040e054730e354db008463593194015212d20c"


### PR DESCRIPTION
Sometimes when viewing the offline version of an exam, dropdowns take
the full width of the page. My current hypothesis is that this is caused
by a race condition in the exam rendering code. If the stylesheet hasn't
loaded before the exam is rendered, the dropdown is rendered as a block
element since the default styling for <div> elements is applied.  This
causes the rendering code to incorrectly calculate dropdown width to be
100%.

As a fix, inline the content of main.css to offline HTML files directly.
This ensures that the CSS has been applied before the rendering code is
fired, and as a side benefit, it removes potential flashing, since all
critical CSS is now included in the document head.

This increases the size of the HTML files by approximately 41kb (the
current size of main.css), but I consider that to be worth the tradeoff.