### PR TITLE
Scanner exam support

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "8.0.1"
+  "version": "8.0.1",
+  "exact": true
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "react-test-renderer": "^16.12.0",
     "redux": "^4.0.1",
     "redux-saga": "^1.1.3",
-    "rich-text-editor": "^4.7.2",
     "sanitize-html": "^1.19.1",
     "tmp-promise": "^2.0.2",
     "ts-jest": "^25.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react-test-renderer": "^16.12.0",
     "redux": "^4.0.1",
     "redux-saga": "^1.1.3",
-    "rich-text-editor": "^4.7.1",
+    "rich-text-editor": "^4.7.2",
     "sanitize-html": "^1.19.1",
     "tmp-promise": "^2.0.2",
     "ts-jest": "^25.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,5 +17,8 @@
   },
   "peerDependencies": {
     "react": "^16.10.2"
+  },
+  "devDependencies": {
+    "rich-text-editor": "^4.7.2"
   }
 }

--- a/packages/core/src/components/Exam.tsx
+++ b/packages/core/src/components/Exam.tsx
@@ -148,10 +148,10 @@ export class Exam extends PureComponent<ExamProps> {
                   )}
                 </Section>
                 {renderChildNodes(root)}
+                <SaveIndicator />
               </main>
             )}
           </ExamContext.Consumer>
-          <SaveIndicator />
         </I18nextProvider>
       </Provider>
     )

--- a/packages/core/src/css/koe-print.less
+++ b/packages/core/src/css/koe-print.less
@@ -1,0 +1,26 @@
+/**
+  To be removed after next abitti release (K2020)
+ */
+@media print {
+  .k-exam-html {
+    font-size: 12px;
+    line-height: 18px;
+
+    .k-exam-body {
+      margin: 0;
+      background-color: #fff;
+
+      &--attachments {
+        background-color: #fff;
+      }
+    }
+  }
+
+  .k-exam-content {
+    display: block;
+  }
+
+  .k-finish-exam-container {
+    box-shadow: none;
+  }
+}

--- a/packages/core/src/css/koe-print.less
+++ b/packages/core/src/css/koe-print.less
@@ -13,6 +13,10 @@
       &--attachments {
         background-color: #fff;
       }
+
+      .rich-text-editor-tools {
+        display: none !important;
+      }
     }
   }
 

--- a/packages/core/src/css/print.less
+++ b/packages/core/src/css/print.less
@@ -1,11 +1,44 @@
 // Here be dragons…
 
 @media print {
+  html {
+    font-size: 12px;
+    line-height: 18px;
+  }
+
+  .k-exam-html .k-exam-body {
+    margin: 0;
+    background-color: #fff;
+
+    &--attachments {
+      background-color: #fff;
+    }
+
+    .rich-text-editor-tools {
+      display: none !important;
+    }
+  }
+
+  .k-exam-content {
+    display: block;
+  }
+
+  .save-indicator {
+    display: none;
+  }
+
+  .k-finish-exam-container {
+    box-shadow: none;
+  }
+
+  .text-answer {
+    box-shadow: none;
+    border: 1px solid #000;
+  }
+
   .e-exam {
     max-width: none !important;
     color: #000;
-    font-size: 12px;
-    line-height: 18px;
 
     button {
       background: none !important;

--- a/packages/core/src/css/print.less
+++ b/packages/core/src/css/print.less
@@ -6,18 +6,18 @@
     line-height: 18px;
   }
 
-  .save-indicator {
-    display: none;
-  }
-
-  .text-answer {
-    box-shadow: none;
-    border: 1px solid #000;
-  }
-
   .e-exam {
     max-width: none !important;
     color: #000;
+
+    .save-indicator {
+      display: none;
+    }
+
+    .text-answer {
+      box-shadow: none;
+      border: 1px solid #000;
+    }
 
     button {
       background: none !important;

--- a/packages/core/src/css/print.less
+++ b/packages/core/src/css/print.less
@@ -6,12 +6,6 @@
     line-height: 18px;
   }
 
-  .k-exam-html .k-exam-body {
-    .rich-text-editor-tools {
-      display: none !important;
-    }
-  }
-
   .save-indicator {
     display: none;
   }
@@ -33,12 +27,6 @@
     .e-section {
       padding: 0 !important;
       box-shadow: 0 0 0 0 !important;
-    }
-
-    .rich-text-editor-tools {
-      width: 0;
-      height: 0;
-      overflow: hidden;
     }
   }
 

--- a/packages/core/src/css/print.less
+++ b/packages/core/src/css/print.less
@@ -7,28 +7,13 @@
   }
 
   .k-exam-html .k-exam-body {
-    margin: 0;
-    background-color: #fff;
-
-    &--attachments {
-      background-color: #fff;
-    }
-
     .rich-text-editor-tools {
       display: none !important;
     }
   }
 
-  .k-exam-content {
-    display: block;
-  }
-
   .save-indicator {
     display: none;
-  }
-
-  .k-finish-exam-container {
-    box-shadow: none;
   }
 
   .text-answer {

--- a/packages/mastering/src/createMex.ts
+++ b/packages/mastering/src/createMex.ts
@@ -85,7 +85,9 @@ export async function createMultiMex(
   passphrase: string,
   answersPrivateKey: string,
   outputStream: NodeJS.WritableStream,
-  loadSimulationConfiguration?: NodeJS.ReadableStream
+  loadSimulationConfiguration?: NodeJS.ReadableStream,
+  ktpUpdate?: NodeJS.ReadableStream,
+  koeUpdate?: NodeJS.ReadableStream
 ) {
   const zipFile = new yazl.ZipFile()
   const keyAndIv = deriveAES256KeyAndIv(passphrase)
@@ -104,6 +106,12 @@ export async function createMultiMex(
       answersPrivateKey,
       loadSimulationConfiguration
     )
+  }
+  if (ktpUpdate) {
+    encryptAndSign(zipFile, 'ktp-update.zip', keyAndIv, answersPrivateKey, ktpUpdate)
+  }
+  if (koeUpdate) {
+    encryptAndSign(zipFile, 'koe-update.zip', keyAndIv, answersPrivateKey, koeUpdate)
   }
 
   zipFile.outputStream.pipe(outputStream)

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -26,7 +26,7 @@
     "puppeteer": "^2.0.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "rich-text-editor": "^4.6.1",
+    "rich-text-editor": "^4.7.2",
     "uuid": "^3.3.3",
     "webpack": "^4.41.2",
     "webpack-dev-server": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9843,7 +9843,16 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rich-text-editor@^4.6.1, rich-text-editor@^4.7.1:
+rich-text-editor@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/rich-text-editor/-/rich-text-editor-4.6.1.tgz#522901fce415d439869e59ac52ccc0d1c34ea194"
+  integrity sha512-MbKC5RDHuZoowObgDtJ0GWQcKuGFDTcIOzHFhYsK8qcAw4mNyZkWUu8EuTAXl0LBXi5T3rRL3Tmgx1u1gXIz5w==
+  dependencies:
+    "@digabi/mathquill" "^0.10.3"
+    jquery "^3.3.1"
+    mathjax-node "^2.1.1"
+
+rich-text-editor@^4.7.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/rich-text-editor/-/rich-text-editor-4.7.2.tgz#b69f8b6c6a19b8e525f9e90b795ef39035350648"
   integrity sha512-uHwpJWu45l7ZRRlPG/501JCO0pLPsa9MAz8TOg3Sa/vvbYu5agyDRbG3tISnxfaC78Y12O3KxKUmqIQGJdTptQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9843,15 +9843,6 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rich-text-editor@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/rich-text-editor/-/rich-text-editor-4.6.1.tgz#522901fce415d439869e59ac52ccc0d1c34ea194"
-  integrity sha512-MbKC5RDHuZoowObgDtJ0GWQcKuGFDTcIOzHFhYsK8qcAw4mNyZkWUu8EuTAXl0LBXi5T3rRL3Tmgx1u1gXIz5w==
-  dependencies:
-    "@digabi/mathquill" "^0.10.3"
-    jquery "^3.3.1"
-    mathjax-node "^2.1.1"
-
 rich-text-editor@^4.7.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/rich-text-editor/-/rich-text-editor-4.7.2.tgz#b69f8b6c6a19b8e525f9e90b795ef39035350648"


### PR DESCRIPTION
- Optionally add and sign update scripts in multi-mex creation
- Add print style fixes to use in scanner exams. Need to be in exam-engine for now, since scanner exams need to be tested with already released Abitti USB images.