### PR TITLE
WIP: Refactor createMex API

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "8.2.0",
+  "version": "8.2.1-refactor-create-mex-api.0",
   "exact": true
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-cli",
-  "version": "8.2.0",
+  "version": "8.2.1-refactor-create-mex-api.0",
   "main": "index.js",
   "license": "EUPL-1.1",
   "files": [
@@ -10,9 +10,9 @@
     "ee": "./dist/index.js"
   },
   "dependencies": {
-    "@digabi/exam-engine-exams": "8.2.0",
-    "@digabi/exam-engine-mastering": "8.2.0",
-    "@digabi/exam-engine-rendering": "8.2.0",
+    "@digabi/exam-engine-exams": "8.2.1-refactor-create-mex-api.0",
+    "@digabi/exam-engine-mastering": "8.2.1-refactor-create-mex-api.0",
+    "@digabi/exam-engine-rendering": "8.2.1-refactor-create-mex-api.0",
     "lodash": "^4.17.15",
     "ora": "^4.0.3",
     "uuid": "^3.3.3",

--- a/packages/exams/package.json
+++ b/packages/exams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-exams",
-  "version": "8.2.0",
+  "version": "8.2.1-refactor-create-mex-api.0",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.1",
   "main": "dist/index.js",
@@ -21,6 +21,6 @@
     "prepublishOnly": "yarn build && find . -name '*.xml' -print0 | xargs -0 -n 1 node ../cli/dist/index.js create-mex -p salasana -n nsa-scripts.zip -s security-codes.json -k \"${ANSWERS_PRIVATE_KEY:?must be set}\" "
   },
   "dependencies": {
-    "@digabi/exam-engine-mastering": "8.2.0"
+    "@digabi/exam-engine-mastering": "8.2.1-refactor-create-mex-api.0"
   }
 }

--- a/packages/mastering/package.json
+++ b/packages/mastering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-mastering",
-  "version": "8.2.0",
+  "version": "8.2.1-refactor-create-mex-api.0",
   "main": "dist/index.js",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.1",

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-rendering",
-  "version": "8.2.0",
+  "version": "8.2.1-refactor-create-mex-api.0",
   "main": "./dist/index.js",
   "license": "EUPL-1.1",
   "files": [
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "@digabi/exam-engine-core": "8.2.0",
-    "@digabi/exam-engine-mastering": "8.2.0",
+    "@digabi/exam-engine-mastering": "8.2.1-refactor-create-mex-api.0",
     "css-loader": "^3.2.1",
     "dexie": "^2.0.4",
     "file-loader": "^5.0.2",


### PR DESCRIPTION
Refactor the optional parameters in createMex API to be handled same way as in mastering API.

WIP: Only covers `createMultiMex` now: `securityCodes` and `json` parameters in `createMex` should also be handled the same way.

All PRs:
- exam-engine, https://github.com/digabi/exam-engine/pull/189
- yo-tools, https://github.com/digabi/yo-tools/pull/62
- integration-tests, https://github.com/digabi/integration-tests/pull/196
- public-exams, https://github.com/digabi/public-exams/pull/6