### PR TITLE
Reduce puppeteer test flakiness

### DIFF
--- a/packages/rendering/__tests__/puppeteerUtils.ts
+++ b/packages/rendering/__tests__/puppeteerUtils.ts
@@ -2,7 +2,7 @@
 
 import puppeteer, { Browser, Page } from 'puppeteer'
 
-const isInDebugMode = (process.env.PUPPETEER_DEBUG || '') === '1'
+const isInDebugMode = process.env.PUPPETEER_DEBUG === '1'
 
 export function initPuppeteer() {
   let browser: Browser

--- a/packages/rendering/__tests__/puppeteerUtils.ts
+++ b/packages/rendering/__tests__/puppeteerUtils.ts
@@ -24,6 +24,11 @@ export function initPuppeteer() {
   }
 }
 
+export async function loadExam(page: Page, url: string) {
+  await page.goto(url)
+  await page.waitForSelector('.e-exam')
+}
+
 export async function delay(millis: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, millis))
 }

--- a/packages/rendering/__tests__/testCasTransition.ts
+++ b/packages/rendering/__tests__/testCasTransition.ts
@@ -1,7 +1,7 @@
 import { resolveExam } from '@digabi/exam-engine-exams'
 import { PreviewContext, previewExam } from '@digabi/exam-engine-rendering'
 import { Page } from 'puppeteer'
-import { initPuppeteer } from './puppeteerUtils'
+import { initPuppeteer, loadExam } from './puppeteerUtils'
 
 describe('testCasTransition.ts - Allowing CAS software in a math exam', () => {
   const createPage = initPuppeteer()
@@ -20,8 +20,7 @@ describe('testCasTransition.ts - Allowing CAS software in a math exam', () => {
   })
 
   it('hides questions of the first section after clicking enable CAS button', async () => {
-    await page.goto(ctx.url)
-    await page.waitForSelector('.e-exam')
+    await loadExam(page, ctx.url)
 
     await assertQuestionVisibility(true)
     await clickToggleCas(true)

--- a/packages/rendering/__tests__/testScoredTextAnswers.ts
+++ b/packages/rendering/__tests__/testScoredTextAnswers.ts
@@ -2,7 +2,7 @@ import { QuestionId } from '@digabi/exam-engine-core'
 import { resolveExam } from '@digabi/exam-engine-exams'
 import { PreviewContext, previewExam } from '@digabi/exam-engine-rendering'
 import { Page } from 'puppeteer'
-import { initPuppeteer } from './puppeteerUtils'
+import { initPuppeteer, loadExam } from './puppeteerUtils'
 
 describe('testScoredTextAnswers.ts — Scored text answer interactions', () => {
   const createPage = initPuppeteer()
@@ -22,8 +22,7 @@ describe('testScoredTextAnswers.ts — Scored text answer interactions', () => {
   const secondAnswerId = 82
 
   it('highlights the hint when focusing a scored text answer', async () => {
-    await page.goto(ctx.url)
-    await page.waitForSelector('.e-exam')
+    await loadExam(page, ctx.url)
 
     await focusAnswer(firstAnswerId)
     await assertAnswerHintHighlighted(firstAnswerId)

--- a/packages/rendering/__tests__/testTextAnswers.ts
+++ b/packages/rendering/__tests__/testTextAnswers.ts
@@ -1,9 +1,8 @@
 import { resolveExam } from '@digabi/exam-engine-exams'
 import { PreviewContext, previewExam } from '@digabi/exam-engine-rendering'
-import { DirectNavigationOptions, Page } from 'puppeteer'
-import { assertElementDoesNotExist, delay, getTextContent, initPuppeteer } from './puppeteerUtils'
+import { Page } from 'puppeteer'
+import { assertElementDoesNotExist, delay, getTextContent, initPuppeteer, loadExam } from './puppeteerUtils'
 
-const navOptions: DirectNavigationOptions = { waitUntil: 'networkidle0' }
 describe('testTextAnswers.ts — Text answer interactions', () => {
   const createPage = initPuppeteer()
   let page: Page
@@ -19,7 +18,7 @@ describe('testTextAnswers.ts — Text answer interactions', () => {
   })
 
   it('updates the character count', async () => {
-    await page.goto(ctx.url, navOptions)
+    await loadExam(page, ctx.url)
 
     await type('h')
     await assertCharacterCount(1)
@@ -35,7 +34,7 @@ describe('testTextAnswers.ts — Text answer interactions', () => {
   })
 
   it('updates the saved indicator after a delay', async () => {
-    await page.goto(ctx.url, navOptions)
+    await loadExam(page, ctx.url)
 
     await assertSaveIndicatorNotPresent()
 
@@ -49,7 +48,7 @@ describe('testTextAnswers.ts — Text answer interactions', () => {
     await delay(2000)
     await assertIsSaved()
 
-    await page.reload(navOptions)
+    await loadExam(page, ctx.url)
     await assertIsSaved()
   })
 


### PR DESCRIPTION
Waiting for the page to be loade with puppeteer's networkidle0 doesn't
seem to be bulletproof. Antti first noticed this in e5924ab6 and we've
some test failures in the remaining networkidle0 tests since then [1],
so let's just use the waitForSelector('.e-exam')-strategy everywhere.

[1] https://travis-ci.org/digabi/exam-engine/jobs/652366353?utm_medium=notification&utm_source=github_status