### PR TITLE
Add a performance budget

### DIFF
--- a/packages/core/webpack.config.js
+++ b/packages/core/webpack.config.js
@@ -2,6 +2,11 @@ const path = require('path')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 
+// Try to keep the bundle size under this threshold. Really, it should be much
+// smaller than that.
+const maxJsSize = 1024 * 1024
+const maxCssSize = 50 * 1024
+
 module.exports = function() {
   const plugins = [
     new MiniCssExtractPlugin({
@@ -57,7 +62,9 @@ module.exports = function() {
       }
     },
     performance: {
-      hints: false
+      maxAssetSize: maxJsSize,
+      maxEntrypointSize: maxJsSize + maxCssSize,
+      hints: 'error'
     }
   }
 }


### PR DESCRIPTION
Use the webpack performance budget feature to check that the bundle size
doesn't go over our threshold. We should try to lower the threshold in
the future (html-sanitize still takes like 600kB of space), but for now,
they're quite large.