### PR TITLE
Add support for censor and inspection gradings in AnswerScore interface

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "9.2.1",
+  "version": "9.2.2",
   "exact": true
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-cli",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "main": "index.js",
   "license": "EUPL-1.1",
   "files": [
@@ -10,9 +10,9 @@
     "ee": "./dist/index.js"
   },
   "dependencies": {
-    "@digabi/exam-engine-exams": "9.2.1",
-    "@digabi/exam-engine-mastering": "9.2.1",
-    "@digabi/exam-engine-rendering": "9.2.1",
+    "@digabi/exam-engine-exams": "9.2.2",
+    "@digabi/exam-engine-mastering": "9.2.2",
+    "@digabi/exam-engine-rendering": "9.2.2",
     "lodash": "^4.17.15",
     "ora": "^4.0.3",
     "uuid": "^7.0.2",

--- a/packages/core/__tests__/testExamRendering.tsx
+++ b/packages/core/__tests__/testExamRendering.tsx
@@ -1,4 +1,4 @@
-import { AnswerScore, Attachments, Exam, ExamAnswer, parseExam, Results } from '@digabi/exam-engine-core'
+import { Attachments, Exam, ExamAnswer, parseExam, PregradingScore, Results, Scores } from '@digabi/exam-engine-core'
 import { listExams } from '@digabi/exam-engine-exams'
 import {
   getMediaMetadataFromLocalFile,
@@ -56,15 +56,20 @@ for (const exam of listExams()) {
   })
 }
 
-function mkScores(gradingStructure: GradingStructure): AnswerScore[] {
+function mkScores(gradingStructure: GradingStructure): Scores {
   return gradingStructure.questions
     .filter((question): question is TextQuestion => question.type === 'text')
-    .map((question, i) => ({
-      questionId: question.id,
-      scoreValue: Math.min(question.maxScore, i),
-      comment: `Comment to question ${question.displayNumber}`,
-      annotations: [{ startIndex: 0, length: 0, message: `Annotation to question ${question.displayNumber}` }]
-    }))
+    .map((question, i) => ({ [question.id]: [createPregradingScore(question, i)] }))
+    .reduce((p, c) => ({ ...p, ...c }), {})
+}
+
+function createPregradingScore(question: { maxScore: number; displayNumber: string }, i: number): PregradingScore {
+  return {
+    type: 'pregrading',
+    score: Math.min(question.maxScore, i),
+    comment: `Comment to question ${question.displayNumber}`,
+    annotations: [{ startIndex: 0, length: 0, message: `Annotation to question ${question.displayNumber}` }]
+  }
 }
 
 function mkAnswers(gradingStructure: GradingStructure): ExamAnswer[] {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-core",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "main": "dist/main-bundle.js",
   "types": "dist/index.d.ts",
   "author": "Matriculation Examination Board, Finland",

--- a/packages/core/src/components/results/AnnotationList.tsx
+++ b/packages/core/src/components/results/AnnotationList.tsx
@@ -5,7 +5,7 @@ import { getNumericAttribute } from '../../dom-utils'
 import { shortDisplayNumber } from '../../shortDisplayNumber'
 import { mapMaybe } from '../../utils'
 import { QuestionContext } from '../QuestionContext'
-import { ResultsContext } from './ResultsContext'
+import { findPregradingScore, ResultsContext } from './ResultsContext'
 
 function ResultsAnnotationList() {
   const { t } = useTranslation()
@@ -14,7 +14,7 @@ function ResultsAnnotationList() {
 
   const answersAndScores = mapMaybe(answers, answer => {
     const questionId = getNumericAttribute(answer, 'question-id')
-    const score = scores.find(s => s.questionId === questionId)
+    const score = findPregradingScore(scores, questionId!)
     return score?.annotations.length ? ([answer, score] as const) : undefined
   })
 

--- a/packages/core/src/components/results/Results.tsx
+++ b/packages/core/src/components/results/Results.tsx
@@ -13,7 +13,7 @@ import ExamSectionTitle from '../ExamSectionTitle'
 import Formula from '../Formula'
 import RenderChildNodes from '../RenderChildNodes'
 import Section from '../Section'
-import { AnswerScore } from '../types'
+import { Scores } from '../types'
 import ResultsChoiceAnswer from './ResultsChoiceAnswer'
 import { ResultsContext, withResultsContext } from './ResultsContext'
 import ResultsDropdownAnswer from './ResultsDropdownAnswer'
@@ -28,7 +28,7 @@ export interface ResultsProps extends CommonExamProps {
   /** Custom grading text to be displayed for the whole exam. For example total grade for the exam. */
   gradingText?: string
   /** Scores for exam questions */
-  scores: AnswerScore[]
+  scores: Scores
 }
 
 const renderChildNodes = createRenderChildNodes({

--- a/packages/core/src/components/results/ResultsTextAnswer.tsx
+++ b/packages/core/src/components/results/ResultsTextAnswer.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getNumericAttribute } from '../../dom-utils'
@@ -30,7 +31,7 @@ function ResultsTextAnswer({ element }: ExamComponentProps) {
           <div className="answer">
             <div className="e-multiline-results-text-answer answer-text-container">
               <div
-                className="answerText"
+                className={classNames('answerText', { 'e-pre-wrap': type === 'multi-line' })}
                 data-annotations={JSON.stringify(score ? score.annotations : [])}
                 dangerouslySetInnerHTML={{ __html: value! }}
               />

--- a/packages/core/src/components/results/ResultsTextAnswer.tsx
+++ b/packages/core/src/components/results/ResultsTextAnswer.tsx
@@ -6,7 +6,7 @@ import { shortDisplayNumber } from '../../shortDisplayNumber'
 import AnswerToolbar from '../AnswerToolbar'
 import { QuestionContext } from '../QuestionContext'
 import { ExamComponentProps, TextAnswer } from '../types'
-import { findScore, ResultsContext } from './ResultsContext'
+import { findPregradingScore, ResultsContext } from './ResultsContext'
 import ResultsExamQuestionScore from './ResultsExamQuestionScore'
 
 function ResultsTextAnswer({ element }: ExamComponentProps) {
@@ -18,7 +18,7 @@ function ResultsTextAnswer({ element }: ExamComponentProps) {
   const answer = answersByQuestionId[questionId] as TextAnswer | undefined
   const value = answer && answer.value
   const displayNumber = shortDisplayNumber(element.getAttribute('display-number')!)
-  const score = findScore(scores, questionId)
+  const score = findPregradingScore(scores, questionId)
   const comment = score?.comment
   const type = (element.getAttribute('type') || 'single-line') as 'rich-text' | 'multi-line' | 'single-line'
 
@@ -27,7 +27,7 @@ function ResultsTextAnswer({ element }: ExamComponentProps) {
     case 'multi-line': {
       return (
         <>
-          {score && <ResultsExamQuestionScore score={score.scoreValue} maxScore={maxScore} />}
+          {score && <ResultsExamQuestionScore score={score.score} maxScore={maxScore} />}
           <div className="answer">
             <div className="e-multiline-results-text-answer answer-text-container">
               <div
@@ -66,7 +66,7 @@ function ResultsTextAnswer({ element }: ExamComponentProps) {
           </span>
           {score && (
             <ResultsExamQuestionScore
-              score={score.scoreValue}
+              score={score.score}
               maxScore={maxScore}
               displayNumber={answers.length > 1 ? displayNumber : undefined}
             />

--- a/packages/core/src/components/types.ts
+++ b/packages/core/src/components/types.ts
@@ -24,17 +24,41 @@ export type ExamAnswer = TextAnswer | RichTextAnswer | ChoiceAnswer
 
 export type SaveState = 'initial' | 'saving' | 'saved'
 
+export type Scores = Record<QuestionId, QuestionScore>
+
+export type ManualScore = PregradingScore | CensorScore | InspectionScore
+
+export type QuestionScore = AutogradedScore | ManualScore[]
+
+export interface AutogradedScore {
+  type: 'autograded'
+  score: number
+}
+
+export interface PregradingScore {
+  type: 'pregrading'
+  score?: number
+  comment?: string
+  annotations: Annotation[]
+}
+
+export interface CensorScore {
+  type: 'censor'
+  scores: Array<{ score: number; shortCode: string }>
+  annotations: Annotation[]
+  comment?: string
+}
+
+export interface InspectionScore {
+  type: 'inspection'
+  score: number
+  shortCodes: [string, string] | [string, string, string]
+}
+
 export interface Annotation {
   startIndex: number
   length: number
   message: string
-}
-
-export interface AnswerScore {
-  questionId: number
-  scoreValue: number | undefined
-  comment?: string
-  annotations: Annotation[]
 }
 
 /**

--- a/packages/core/src/css/typography.less
+++ b/packages/core/src/css/typography.less
@@ -175,6 +175,10 @@
     white-space: nowrap;
   }
 
+  .e-pre-wrap {
+    white-space: pre-wrap;
+  }
+
   .e-normal {
     white-space: normal;
   }

--- a/packages/exams/package.json
+++ b/packages/exams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-exams",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.1",
   "main": "dist/index.js",
@@ -21,6 +21,6 @@
     "prepublishOnly": "yarn build && find . -name '*.xml' -print0 | xargs -0 -n 1 node ../cli/dist/index.js create-mex -p salasana -n nsa-scripts.zip -s security-codes.json -k \"${ANSWERS_PRIVATE_KEY:?must be set}\" "
   },
   "dependencies": {
-    "@digabi/exam-engine-mastering": "9.2.1"
+    "@digabi/exam-engine-mastering": "9.2.2"
   }
 }

--- a/packages/mastering/package.json
+++ b/packages/mastering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-mastering",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "main": "dist/index.js",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.1",
@@ -15,7 +15,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@digabi/exam-engine-core": "9.2.1",
+    "@digabi/exam-engine-core": "9.2.2",
     "ffprobe": "^1.1.0",
     "ffprobe-static": "^3.0.0",
     "glob": "^7.1.6",

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-rendering",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "main": "./dist/index.js",
   "license": "EUPL-1.1",
   "files": [
@@ -13,8 +13,8 @@
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^7.8.7",
     "@babel/runtime": "^7.8.7",
-    "@digabi/exam-engine-core": "9.2.1",
-    "@digabi/exam-engine-mastering": "9.2.1",
+    "@digabi/exam-engine-core": "9.2.2",
+    "@digabi/exam-engine-mastering": "9.2.2",
     "babel-loader": "^8.0.6",
     "child-process-promise": "^2.2.1",
     "css-loader": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,9 +2490,9 @@
   integrity sha512-RiX1I0lK9WFLFqy2xOxke396f0wKIzk5sAll0tL4J4XDYJXURI7JOs96XQb3nP+2gEpQ/LutBb66jgiT5oQshQ==
 
 "@types/webpack-dev-server@^3.9.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-3.10.0.tgz#5121ed285357b3b7463cac0d35e9b93819cf2167"
-  integrity sha512-ct/g/4WEEqOpXPqGX31TlZSzF1Sb7LXIViBz0oBSdH08XtNgY/hq/faXkw0yTxqvj7HJwS8dy2ggzqHposf1fQ==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-3.10.1.tgz#93b7133cc9dab1ca1b76659f5ef8b763ad54c28a"
+  integrity sha512-2nwwQ/qHRghUirvG/gEDkOQDa+d881UTJM7EG9ok5KNaYCjYVvy7fdaO528Lcym9OQDn75SvruPYVVvMJxqO0g==
   dependencies:
     "@types/connect-history-api-fallback" "*"
     "@types/express" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6345,9 +6345,9 @@ humanize-ms@^1.2.1:
     ms "^2.0.0"
 
 i18next@^19.0.1:
-  version "19.3.2"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.3.2.tgz#a17c3c8bb0dd2d8c4a8963429df99730275b3282"
-  integrity sha512-QDBQ8MqFWi4+L9OQjjZEKVyg9uSTy3NTU3Ri53QHe7nxtV+KD4PyLB8Kxu58gr6b9y5l8cU3mCiNHVeoxPMzAQ==
+  version "19.3.3"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.3.3.tgz#04bd79b315e5fe2c87ab8f411e5d55eda0a17bd8"
+  integrity sha512-CnuPqep5/JsltkGvQqzYN4d79eCe0TreCBRF3a8qHHi8x4SON1qqZ/pvR2X7BfNkNqpA5HXIqw0E731H+VsgSg==
   dependencies:
     "@babel/runtime" "^7.3.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,9 +2443,9 @@
   integrity sha512-sfO4vwDEH5hpm9GHQMkcJaRUWgcrlgJn9YLQv+6l9JBQk+Xe4nx9zfbHgS+3x1sMwZUnFc0sgTY0eAHr9Foqhw==
 
 "@types/sanitize-html@^1.20.2":
-  version "1.20.2"
-  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-1.20.2.tgz#59777f79f015321334e3a9f28882f58c0a0d42b8"
-  integrity sha512-SrefiiBebGIhxEFkpbbYOwO1S6+zQLWAC4s4tipchlHq1aO9bp0xiapM7Zm0ml20MF+3OePWYdksB1xtneKPxg==
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-1.22.0.tgz#9bf3a13aeab6e38d130d8ba34bb443956b75bc3d"
+  integrity sha512-zRtkG+Z9ikdEyIQL6ZouqZIPWnzoioJxgxAUFOc91f+nC8yB4GOMzGpy9V3WYfmkjaVNL4zlsycwHWykFq1HNg==
   dependencies:
     "@types/htmlparser2" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12879,10 +12879,10 @@ yargs-parser@^16.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^18.1.0:
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.0.tgz#1b0ab1118ebd41f68bb30e729f4c83df36ae84c3"
-  integrity sha512-o/Jr6JBOv6Yx3pL+5naWSoIA2jJ+ZkMYQG/ie9qFbukBe4uzmBatlXFOiu/tNKRWEtyf+n5w7jc/O16ufqOTdQ==
+yargs-parser@^18.1.1:
+  version "18.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.1.tgz#bf7407b915427fc760fcbbccc6c82b4f0ffcbd37"
+  integrity sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -12956,9 +12956,9 @@ yargs@^14.2.2:
     yargs-parser "^15.0.0"
 
 yargs@^15.0.0, yargs@^15.0.2:
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.0.tgz#403af6edc75b3ae04bf66c94202228ba119f0976"
-  integrity sha512-g/QCnmjgOl1YJjGsnUg2SatC7NUYEiLXJqxNOQU9qSpjzGtGXda9b+OKccr1kLTy8BN9yqEyqfq5lxlwdc13TA==
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
   dependencies:
     cliui "^6.0.0"
     decamelize "^1.2.0"
@@ -12970,7 +12970,7 @@ yargs@^15.0.0, yargs@^15.0.2:
     string-width "^4.2.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^18.1.0"
+    yargs-parser "^18.1.1"
 
 yauzl@2.4.1:
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4526,9 +4526,9 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-url "^7.0.0"
 
 date-fns@^2.0.1, date-fns@^2.8.1:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.10.0.tgz#abd10604d8bafb0bcbd2ba2e9b0563b922ae4b6b"
-  integrity sha512-EhfEKevYGWhWlZbNeplfhIU/+N+x0iCIx7VzKlXma2EdQyznVlZhCptXUY+BegNpPW2kjdx15Rvq503YcXXrcA==
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.11.0.tgz#ec2b44977465b9dcb370021d5e6c019b19f36d06"
+  integrity sha512-8P1cDi8ebZyDxUyUprBXwidoEtiQAawYPGvpfb+Dg0G6JrQ+VozwOmm91xYC0vAv1+0VmLehEPb+isg4BGUFfA==
 
 date-now@^0.1.4:
   version "0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2759,9 +2759,9 @@ acorn-walk@^6.0.1:
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
 acorn@^5.5.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
-  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
+  version "5.7.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
+  integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
 acorn@^6.0.1, acorn@^6.2.1:
   version "6.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11978,9 +11978,9 @@ tslint-config-prettier@^1.18.0:
   integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
 
 tslint-plugin-prettier@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslint-plugin-prettier/-/tslint-plugin-prettier-2.1.0.tgz#e2522d273cb9672d93d0e68f2514fe3c19698c3a"
-  integrity sha512-nMCpU+QSpXtydcWXeZF+3ljIbG/K8SHVZwB7K/MtuoQQFXxXN6watqTSBpVXCInuPFvmjiWkhxeMoUW4N0zgSg==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslint-plugin-prettier/-/tslint-plugin-prettier-2.2.0.tgz#7806e115f054cb6ff7c26806b3f24bd5716208a5"
+  integrity sha512-K4pzyF+ueWw3DEJ7h4MqAZ3tHQBVsay1cRSQ0aDXErEuIdrkC5NKywCebOnKl8GHvTW0C9TrHpRMeo2D8iwI8w==
   dependencies:
     eslint-plugin-prettier "^2.2.0"
     lines-and-columns "^1.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,14 +842,7 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3":
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.1.tgz#b223497bbfbcbbb38116673904debc71470ca528"
-  integrity sha512-SQ0sS7KUJDvgCI2cpZG0nJygO6002oTbhgSuw4WcocsnbxLwL5Q8I3fqbJdyBAc3uFrWZiR2JomseuxSuci3SQ==
-  dependencies:
-    regenerator-runtime "^0.13.2"
-
-"@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
   integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
@@ -4896,9 +4889,9 @@ dot-prop@^4.1.1, dot-prop@^4.2.0:
     is-obj "^1.0.0"
 
 downshift@^5.0.0:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-5.0.4.tgz#d7c8126458bcc0e9a94b1f533fa08c19cb33763f"
-  integrity sha512-vFDJKm7vHU/1IYtYcZl52CdkZ9WKGQEPZzTnDo+X2Tb+yYnnz9M5L9WT/j0EDPZOcB+js94Vf5ylvQsvYpRzrw==
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-5.0.5.tgz#1cc90dc09ae62998ce28a4ce457e0f1cdd0bfcfa"
+  integrity sha512-V1idov3Rkvz1YWA1K67aIx51EgokIDvep4x6KmU7HhsayI8DvTEZBeH4O92zeFVGximKujRO7ChBzBAf4PKWFA==
   dependencies:
     "@babel/runtime" "^7.4.5"
     compute-scroll-into-view "^1.0.9"
@@ -10534,11 +10527,6 @@ regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
-
-regenerator-runtime@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
-  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regenerator-runtime@^0.13.4:
   version "0.13.4"


### PR DESCRIPTION
Types are optional until properly taken into use.
One or more shortCodes can be given to distinct score giver.
Update time will be used to recognize different censors (1, 2 and 3)