### PR TITLE
Add a single grading mode for AnnotationList.tsx and ResultsContext

### DIFF
--- a/packages/core/__tests__/results/AnnotationList.test.tsx
+++ b/packages/core/__tests__/results/AnnotationList.test.tsx
@@ -93,6 +93,22 @@ describe('<AnnotationList />', () => {
       }
       expect(renderWithContext(resultsProps, [defaultAnswer]).toJSON()).toMatchSnapshot()
     })
+
+    it('renders only pregrading without header on oneGradingRound in ResultContext', () => {
+      const resultsProps = {
+        scores: [defaultScores],
+        oneGradingRound: true
+      }
+      expect(renderWithContext(resultsProps, [defaultAnswer]).toJSON()).toMatchSnapshot()
+    })
+
+    it('renders null if no scores and oneGradingRound in ResultContext', () => {
+      const resultsProps = {
+        scores: [],
+        oneGradingRound: true
+      }
+      expect(renderWithContext(resultsProps, [defaultAnswer]).toJSON()).toMatchSnapshot()
+    })
   })
 
   describe('sv-FI', () => {

--- a/packages/core/__tests__/results/AnnotationList.test.tsx
+++ b/packages/core/__tests__/results/AnnotationList.test.tsx
@@ -94,18 +94,18 @@ describe('<AnnotationList />', () => {
       expect(renderWithContext(resultsProps, [defaultAnswer]).toJSON()).toMatchSnapshot()
     })
 
-    it('renders only pregrading without header on oneGradingRound in ResultContext', () => {
+    it('renders only pregrading without header on singleGrading in ResultContext', () => {
       const resultsProps = {
         scores: [defaultScores],
-        oneGradingRound: true
+        singleGrading: true
       }
       expect(renderWithContext(resultsProps, [defaultAnswer]).toJSON()).toMatchSnapshot()
     })
 
-    it('renders null if no scores and oneGradingRound in ResultContext', () => {
+    it('renders null if no scores and singleGrading in ResultContext', () => {
       const resultsProps = {
         scores: [],
-        oneGradingRound: true
+        singleGrading: true
       }
       expect(renderWithContext(resultsProps, [defaultAnswer]).toJSON()).toMatchSnapshot()
     })

--- a/packages/core/__tests__/results/AnnotationList.test.tsx
+++ b/packages/core/__tests__/results/AnnotationList.test.tsx
@@ -80,6 +80,39 @@ describe('<AnnotationList />', () => {
       expect(renderWithContext(resultsProps, [defaultAnswer]).toJSON()).toMatchSnapshot()
     })
 
+    it('filters empty annotations', () => {
+      const resultsProps = {
+        scores: [
+          {
+            ..._.pick(defaultScores, 'pregrading', 'answerId', 'questionId'),
+            ...{
+              pregrading: {
+                score: 1,
+                annotations: [
+                  {
+                    startIndex: 0,
+                    length: 1,
+                    message: 'Before empty annotation'
+                  },
+                  {
+                    startIndex: 1,
+                    length: 1,
+                    message: ''
+                  },
+                  {
+                    startIndex: 2,
+                    length: 1,
+                    message: 'After empty annotation'
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+      expect(renderWithContext(resultsProps, [defaultAnswer]).toJSON()).toMatchSnapshot()
+    })
+
     it('renders with only censoring annotations', () => {
       const resultsProps = {
         scores: [_.pick(defaultScores, 'censoring', 'answerId', 'questionId')]

--- a/packages/core/__tests__/results/__snapshots__/AnnotationList.test.tsx.snap
+++ b/packages/core/__tests__/results/__snapshots__/AnnotationList.test.tsx.snap
@@ -4,6 +4,28 @@ exports[`<AnnotationList /> fi-FI renders empty without annotations 1`] = `null`
 
 exports[`<AnnotationList /> fi-FI renders empty without score 1`] = `null`;
 
+exports[`<AnnotationList /> fi-FI renders null if no scores and oneGradingRound in ResultContext 1`] = `null`;
+
+exports[`<AnnotationList /> fi-FI renders only pregrading without header on oneGradingRound in ResultContext 1`] = `
+<div
+  className="e-annotation-list e-columns e-mrg-t-2"
+>
+  <div
+    className="e-column e-column--6"
+  >
+    <ol
+      className="e-list-data e-pad-l-0 e-font-size-s"
+    >
+      <li
+        data-list-number="1)"
+      >
+        Test pregrading annotation
+      </li>
+    </ol>
+  </div>
+</div>
+`;
+
 exports[`<AnnotationList /> fi-FI renders with only censoring annotations 1`] = `
 <div
   className="e-annotation-list e-columns e-mrg-t-2"

--- a/packages/core/__tests__/results/__snapshots__/AnnotationList.test.tsx.snap
+++ b/packages/core/__tests__/results/__snapshots__/AnnotationList.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`<AnnotationList /> fi-FI renders empty without annotations 1`] = `null`
 
 exports[`<AnnotationList /> fi-FI renders empty without score 1`] = `null`;
 
-exports[`<AnnotationList /> fi-FI renders null if no scores and oneGradingRound in ResultContext 1`] = `null`;
+exports[`<AnnotationList /> fi-FI renders null if no scores and singleGrading in ResultContext 1`] = `null`;
 
-exports[`<AnnotationList /> fi-FI renders only pregrading without header on oneGradingRound in ResultContext 1`] = `
+exports[`<AnnotationList /> fi-FI renders only pregrading without header on singleGrading in ResultContext 1`] = `
 <div
   className="e-annotation-list e-columns e-mrg-t-2"
 >
   <div
-    className="e-column e-column--6"
+    className="e-column e-column--10"
   >
     <ol
       className="e-list-data e-pad-l-0 e-font-size-s"

--- a/packages/core/__tests__/results/__snapshots__/AnnotationList.test.tsx.snap
+++ b/packages/core/__tests__/results/__snapshots__/AnnotationList.test.tsx.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<AnnotationList /> fi-FI filters empty annotations 1`] = `
+<div
+  className="e-annotation-list e-columns e-mrg-t-2"
+>
+  <div
+    className="e-column e-column--6"
+  >
+    <h5>
+      Valmistavan arvostelun merkinnät
+    </h5>
+    <ol
+      className="e-list-data e-pad-l-0 e-font-size-s"
+    >
+      <li
+        data-list-number="1)"
+      >
+        Before empty annotation
+      </li>
+      <li
+        data-list-number="2)"
+      >
+        After empty annotation
+      </li>
+    </ol>
+  </div>
+  <div
+    className="e-column e-column--6"
+  >
+    <h5>
+      Sensorin merkinnät
+    </h5>
+    <ol
+      className="e-list-data e-pad-l-0 e-font-size-s"
+    />
+  </div>
+</div>
+`;
+
 exports[`<AnnotationList /> fi-FI renders empty without annotations 1`] = `null`;
 
 exports[`<AnnotationList /> fi-FI renders empty without score 1`] = `null`;

--- a/packages/core/src/components/results/AnnotationList.tsx
+++ b/packages/core/src/components/results/AnnotationList.tsx
@@ -24,7 +24,7 @@ const hasAnnotations = (score: Score) =>
 const getPrefix = (answers: Element[], answer: Element) =>
   answers.length > 1 ? shortDisplayNumber(answer.getAttribute('display-number')!) : ''
 
-export const ResultsAnnotationListComponent = ({ i18nTitleKey, annotations }: AnnotationListProps) => {
+const AnnotationListComponent = ({ i18nTitleKey, annotations }: AnnotationListProps) => {
   const { t } = useTranslation()
 
   return annotations ? (
@@ -43,7 +43,7 @@ export const ResultsAnnotationListComponent = ({ i18nTitleKey, annotations }: An
 
 function ResultsAnnotationList() {
   const { answers } = useContext(QuestionContext)
-  const { scores } = useContext(ResultsContext)
+  const { scores, oneGradingRound } = useContext(ResultsContext)
 
   const answersAndScores = mapMaybe(answers, answer => {
     const questionId = getNumericAttribute(answer, 'question-id')
@@ -74,11 +74,17 @@ function ResultsAnnotationList() {
 
   return pregradingAnnotations.length || censoringAnnotations.length ? (
     <div className="e-annotation-list e-columns e-mrg-t-2">
-      <ResultsAnnotationListComponent
-        i18nTitleKey={'grading.pregrading-annotations'}
-        annotations={pregradingAnnotations}
-      />
-      <ResultsAnnotationListComponent i18nTitleKey={'grading.censor-annotations'} annotations={censoringAnnotations} />
+      {!oneGradingRound ? (
+        <>
+          <AnnotationListComponent
+            i18nTitleKey={'grading.pregrading-annotations'}
+            annotations={pregradingAnnotations}
+          />
+          <AnnotationListComponent i18nTitleKey={'grading.censor-annotations'} annotations={censoringAnnotations} />
+        </>
+      ) : <>
+        <AnnotationListComponent annotations={pregradingAnnotations} />
+      </>}
     </div>
   ) : null
 }

--- a/packages/core/src/components/results/AnnotationList.tsx
+++ b/packages/core/src/components/results/AnnotationList.tsx
@@ -74,7 +74,11 @@ function ResultsAnnotationList() {
 
   return pregradingAnnotations.length || censoringAnnotations.length ? (
     <div className="e-annotation-list e-columns e-mrg-t-2">
-      {!singleGrading ? (
+      {singleGrading ? (
+        <div className="e-column e-column--10">
+          <AnnotationListComponent annotations={pregradingAnnotations} />
+        </div>
+      ) : (
         <>
           <div className="e-column e-column--6">
             <AnnotationListComponent
@@ -86,10 +90,6 @@ function ResultsAnnotationList() {
             <AnnotationListComponent i18nTitleKey={'grading.censor-annotations'} annotations={censoringAnnotations} />
           </div>
         </>
-      ) : (
-        <div className="e-column e-column--10">
-          <AnnotationListComponent annotations={pregradingAnnotations} />
-        </div>
       )}
     </div>
   ) : null

--- a/packages/core/src/components/results/AnnotationList.tsx
+++ b/packages/core/src/components/results/AnnotationList.tsx
@@ -28,7 +28,7 @@ const AnnotationListComponent = ({ i18nTitleKey, annotations }: AnnotationListPr
   const { t } = useTranslation()
 
   return annotations ? (
-    <div className="e-column e-column--6">
+    <>
       {i18nTitleKey && <h5>{t(i18nTitleKey)}</h5>}
       <ol className="e-list-data e-pad-l-0 e-font-size-s">
         {annotations.map(({ numbering, message }) => (
@@ -37,13 +37,13 @@ const AnnotationListComponent = ({ i18nTitleKey, annotations }: AnnotationListPr
           </li>
         ))}
       </ol>
-    </div>
+    </>
   ) : null
 }
 
 function ResultsAnnotationList() {
   const { answers } = useContext(QuestionContext)
-  const { scores, oneGradingRound } = useContext(ResultsContext)
+  const { scores, singleGrading } = useContext(ResultsContext)
 
   const answersAndScores = mapMaybe(answers, answer => {
     const questionId = getNumericAttribute(answer, 'question-id')
@@ -74,17 +74,23 @@ function ResultsAnnotationList() {
 
   return pregradingAnnotations.length || censoringAnnotations.length ? (
     <div className="e-annotation-list e-columns e-mrg-t-2">
-      {!oneGradingRound ? (
+      {!singleGrading ? (
         <>
-          <AnnotationListComponent
-            i18nTitleKey={'grading.pregrading-annotations'}
-            annotations={pregradingAnnotations}
-          />
-          <AnnotationListComponent i18nTitleKey={'grading.censor-annotations'} annotations={censoringAnnotations} />
+          <div className="e-column e-column--6">
+            <AnnotationListComponent
+              i18nTitleKey={'grading.pregrading-annotations'}
+              annotations={pregradingAnnotations}
+            />
+          </div>
+          <div className="e-column e-column--6">
+            <AnnotationListComponent i18nTitleKey={'grading.censor-annotations'} annotations={censoringAnnotations} />
+          </div>
         </>
-      ) : <>
-        <AnnotationListComponent annotations={pregradingAnnotations} />
-      </>}
+      ) : (
+        <div className="e-column e-column--10">
+          <AnnotationListComponent annotations={pregradingAnnotations} />
+        </div>
+      )}
     </div>
   ) : null
 }

--- a/packages/core/src/components/results/Results.tsx
+++ b/packages/core/src/components/results/Results.tsx
@@ -28,7 +28,8 @@ export interface ResultsProps extends CommonExamProps {
   /** Custom grading text to be displayed for the whole exam. For example total grade for the exam. */
   gradingText?: string
   /** Scores for exam answers */
-  scores: Score[]
+  scores: Score[],
+  oneGradingRound?: boolean
 }
 
 const renderChildNodes = createRenderChildNodes({

--- a/packages/core/src/components/results/Results.tsx
+++ b/packages/core/src/components/results/Results.tsx
@@ -28,8 +28,8 @@ export interface ResultsProps extends CommonExamProps {
   /** Custom grading text to be displayed for the whole exam. For example total grade for the exam. */
   gradingText?: string
   /** Scores for exam answers */
-  scores: Score[],
-  oneGradingRound?: boolean
+  scores: Score[]
+  singleGrading?: boolean
 }
 
 const renderChildNodes = createRenderChildNodes({

--- a/packages/core/src/components/results/ResultsContext.ts
+++ b/packages/core/src/components/results/ResultsContext.ts
@@ -12,13 +12,14 @@ export interface ResultsContext {
   scores: Score[]
   gradingText: string | undefined
   totalScore: number
+  oneGradingRound?: boolean
 }
 
 export const ResultsContext = React.createContext<ResultsContext>({} as ResultsContext)
 
 export const withResultsContext = withContext<ResultsContext, ResultsProps>(
   ResultsContext,
-  ({ scores, doc, gradingStructure, gradingText, answers }) => {
+  ({ scores, doc, gradingStructure, gradingText, answers, oneGradingRound }) => {
     const answersByQuestionId = _.keyBy(answers, 'questionId')
     const topLevelQuestions = queryAll(doc.documentElement, 'question', false)
     const totalScore = _.sum(
@@ -32,7 +33,8 @@ export const withResultsContext = withContext<ResultsContext, ResultsProps>(
       gradingStructure,
       scores,
       totalScore,
-      gradingText
+      gradingText,
+      oneGradingRound
     }
   }
 )

--- a/packages/core/src/components/results/ResultsContext.ts
+++ b/packages/core/src/components/results/ResultsContext.ts
@@ -12,14 +12,14 @@ export interface ResultsContext {
   scores: Score[]
   gradingText: string | undefined
   totalScore: number
-  oneGradingRound?: boolean
+  singleGrading?: boolean
 }
 
 export const ResultsContext = React.createContext<ResultsContext>({} as ResultsContext)
 
 export const withResultsContext = withContext<ResultsContext, ResultsProps>(
   ResultsContext,
-  ({ scores, doc, gradingStructure, gradingText, answers, oneGradingRound }) => {
+  ({ scores, doc, gradingStructure, gradingText, answers, singleGrading }) => {
     const answersByQuestionId = _.keyBy(answers, 'questionId')
     const topLevelQuestions = queryAll(doc.documentElement, 'question', false)
     const totalScore = _.sum(
@@ -34,7 +34,7 @@ export const withResultsContext = withContext<ResultsContext, ResultsProps>(
       scores,
       totalScore,
       gradingText,
-      oneGradingRound
+      singleGrading
     }
   }
 )


### PR DESCRIPTION
Lisää singleGrading propin Resultsiin, mikä tällä hetkellä vaikuttaa annotaatioiden rendaamiseen seuraavasti:
- Annotaatio-listauksen otsikko jätetään pois
- Rendataan yhdessä listassa pregrading annotaatiot täydellä leveydellä

Lisättiin testejä listaukselle ja tyhjien annotaatioiden filtteröinnille