### PR TITLE
Css korjauksia

### DIFF
--- a/packages/core/__tests__/results/__snapshots__/ResultsExamQuestionManualScore.test.tsx.snap
+++ b/packages/core/__tests__/results/__snapshots__/ResultsExamQuestionManualScore.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with displayNumber whe
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       
     </span>
@@ -51,7 +51,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading and on
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       SE3
     </span>
@@ -72,7 +72,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading and on
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       
     </span>
@@ -102,7 +102,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading and th
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       SE3
     </span>
@@ -123,7 +123,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading and th
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       SE2
     </span>
@@ -144,7 +144,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading and th
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       SE1
     </span>
@@ -165,7 +165,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading and th
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       
     </span>
@@ -195,7 +195,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading score 
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       
     </span>
@@ -225,7 +225,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading, censo
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       IN1, IN2
     </span>
@@ -246,7 +246,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading, censo
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       SE3
     </span>
@@ -267,7 +267,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading, censo
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       SE2
     </span>
@@ -288,7 +288,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading, censo
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       SE1
     </span>
@@ -309,7 +309,7 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading, censo
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       
     </span>
@@ -345,7 +345,7 @@ exports[`<ResultsExamQuestionManualScore /> sv-FI renders with pregrading, censo
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       IN1, IN2
     </span>
@@ -366,7 +366,7 @@ exports[`<ResultsExamQuestionManualScore /> sv-FI renders with pregrading, censo
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       SE3
     </span>
@@ -387,7 +387,7 @@ exports[`<ResultsExamQuestionManualScore /> sv-FI renders with pregrading, censo
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       SE2
     </span>
@@ -408,7 +408,7 @@ exports[`<ResultsExamQuestionManualScore /> sv-FI renders with pregrading, censo
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       SE1
     </span>
@@ -429,7 +429,7 @@ exports[`<ResultsExamQuestionManualScore /> sv-FI renders with pregrading, censo
        p.
     </span>
     <span
-      className="e-font-size-xs e-mrg-r-1 "
+      className="e-font-size-xs e-mrg-r-1 e-result-scorecount-shortcode"
     >
       
     </span>

--- a/packages/core/src/components/results/Results.less
+++ b/packages/core/src/components/results/Results.less
@@ -19,3 +19,8 @@
   width: 1.5ch;
   border-bottom: 1px solid #ccc;
 }
+
+// If several questions are on same row, scores overlap next question. Hack to prevent it.
+table td .e-result-scorecount {
+  margin-right: 0;
+}

--- a/packages/core/src/components/results/ResultsExamQuestionManualScore.tsx
+++ b/packages/core/src/components/results/ResultsExamQuestionManualScore.tsx
@@ -69,7 +69,7 @@ function ScoreRow({ score, shortCode, type, maxScore, latest }: ScoreRowProps & 
         {latest && maxScore ? ` / ${maxScore}` : ''}
         {` p.`}
       </ScoreColumn>
-      <ScoreColumn>{shortCode}</ScoreColumn>
+      <ScoreColumn className="e-result-scorecount-shortcode">{shortCode}</ScoreColumn>
       <ScoreColumn className="e-mrg-r-0">
         <Translation>{t => t(type)}</Translation>
       </ScoreColumn>

--- a/packages/core/src/css/print.less
+++ b/packages/core/src/css/print.less
@@ -44,6 +44,10 @@
       padding: 0 !important;
       box-shadow: 0 0 0 0 !important;
     }
+
+    .e-result-scorecount-shortcode {
+      display: none !important;
+    }
   }
 
   // Dropdown answers


### PR DESCRIPTION
Hide censor and inspection short codes on print.

<img width="1042" alt="Screenshot 2020-03-30 at 14 18 51" src="https://user-images.githubusercontent.com/60091052/77907353-2b91f980-7292-11ea-8464-7db430181226.png">

Do not overlap question with score.

<img width="1151" alt="Screenshot 2020-03-30 at 14 09 08" src="https://user-images.githubusercontent.com/60091052/77907401-406e8d00-7292-11ea-8dc3-0279f962256b.png">
