### PR TITLE
Pienennä exam-engine-coren kokoa

### DIFF
--- a/packages/core/src/parser/parseExam.ts
+++ b/packages/core/src/parser/parseExam.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash-es'
+import * as _ from 'lodash-es'
 import { queryAll } from '../dom-utils'
 
 export default function parseExam(examXml: string, deterministicRendering: boolean = false): XMLDocument {

--- a/packages/core/src/shortDisplayNumber.ts
+++ b/packages/core/src/shortDisplayNumber.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash-es'
+import * as _ from 'lodash-es'
 
 export function shortDisplayNumber(displayName: string): string {
   return _.last(displayName.split('.'))! + '.'

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash-es'
+import * as _ from 'lodash-es'
 import { applyMiddleware, combineReducers, compose, createStore, Store } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 import { fork } from 'redux-saga/effects'

--- a/packages/core/webpack.config.js
+++ b/packages/core/webpack.config.js
@@ -64,7 +64,7 @@ module.exports = function() {
     performance: {
       maxAssetSize: maxJsSize,
       maxEntrypointSize: maxJsSize + maxCssSize,
-      hints: 'warning'
+      hints: 'error'
     }
   }
 }


### PR DESCRIPTION
Pienennä exam-engine-coren kokoa tuomalla ainoastaan ne lodash funktiot joita käytetään. Tämä mahdollistaa muiden lodash funktioiden tiputtamisen main-bundlesta treeshakeammalla.