### PR TITLE
Run tsc when building code in packages/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "scripts": {
     "start": "node packages/cli/dist/start.js",
     "build": "tsc --build && yarn workspace @digabi/exam-engine-core build",
-    "watch": "concurrently -n 'tsc,webpack' -c 'blue,green' 'tsc --build --watch' 'yarn workspace @digabi/exam-engine-core watch'",
+    "watch": "concurrently -n 'tsc,core' -c 'blue,green' 'tsc --build --watch' 'yarn workspace @digabi/exam-engine-core watch'",
     "lerna": "lerna",
     "lint": "yarn workspaces run lint",
     "ee": "node packages/cli/dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,11 +9,11 @@
     "dist"
   ],
   "scripts": {
-    "build": "webpack -p",
-    "watch": "webpack -p --watch",
+    "build": "tsc --build && webpack -p",
+    "watch": "concurrently -n 'tsc,webpack' -c 'blue,green' 'tsc --build --watch' 'webpack -p --watch'",
     "lint": "tslint -p . && tslint -p __tests__",
     "lint-fix-all": "tslint -p . --fix && tslint -p __tests__ --fix",
-    "prepublishOnly": "webpack -p && perl -pi -e 's|&&define.amd||' dist/main-bundle.js # Compatibility with our 💩 AMD loader",
+    "prepublishOnly": "tsc --build && webpack -p && perl -pi -e 's|&&define.amd||' dist/main-bundle.js # Compatibility with our 💩 AMD loader",
     "test": "NODE_ICU_DATA=../../node_modules/full-icu jest"
   },
   "peerDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,6 @@
   },
   "files": [],
   "references": [
-    { "path": "./packages/core" },
     { "path": "./packages/exams" },
     { "path": "./packages/mastering" },
     { "path": "./packages/rendering" },


### PR DESCRIPTION
Only running `yarn prepublishOnly` wouldn't recompile typescript code and resulting package might have old compiled code.