### PR TITLE
Skop API change: the inspection grade object exists even without a score, if inspection is ongoing

### DIFF
--- a/packages/core/src/components/results/ResultsExamQuestionManualScore.tsx
+++ b/packages/core/src/components/results/ResultsExamQuestionManualScore.tsx
@@ -33,7 +33,7 @@ function ResultsExamQuestionManualScore({ scores, maxScore, displayNumber }: Res
 
 function renderNormalizedScores(scores: Score, maxScore?: number) {
   const normalizedScores = [
-    scores.inspection && normalizeInspectionScore(scores.inspection),
+    scores.inspection && scores.inspection.score != null && normalizeInspectionScore(scores.inspection),
     ...(scores.censoring ? normalizeCensoringScores(scores.censoring) : []),
     scores.pregrading && normalizePregradingScore(scores.pregrading),
   ].filter(Boolean) as NormalizedScore[]
@@ -110,8 +110,14 @@ function normalizeCensoringScores(score: CensoringScore): NormalizedScore[] {
   }))
 }
 
-function normalizeInspectionScore(score: InspectionScore): NormalizedScore {
-  return { score: score.score, shortCode: score.shortCodes ? score.shortCodes.join(', ') : '', type: 'ta' }
+function normalizeInspectionScore(score: InspectionScore): NormalizedScore | null {
+  return score.score != null
+    ? {
+        score: score.score,
+        shortCode: score.shortCodes ? score.shortCodes.join(', ') : '',
+        type: 'ta',
+      }
+    : null
 }
 
 export default React.memo(ResultsExamQuestionManualScore)

--- a/packages/core/src/types/Score.ts
+++ b/packages/core/src/types/Score.ts
@@ -29,8 +29,8 @@ export interface CensoringScore {
 }
 
 export interface InspectionScore {
-  score: number
-  shortCodes: [string, string] | [string, string, string]
+  score: number | null
+  shortCodes: [string, string] | [string, string, string] | null
 }
 
 export interface Annotation {


### PR DESCRIPTION
Korjausvaatimuksen ollessa päällä, palauttaa API inspection score objektin, vaikka korjausvaatimuksessa ei olisi vielä annettu pisteitä.