### PR TITLE
additional unit tests for ResultsExamQuestionManualScore component

### DIFF
--- a/packages/core/__tests__/results/ResultsExamQuestionManualScore.test.tsx
+++ b/packages/core/__tests__/results/ResultsExamQuestionManualScore.test.tsx
@@ -89,6 +89,44 @@ describe('<ResultsExamQuestionManualScore />', () => {
       }
       expect(renderWithContext(props, [{} as Element, {} as Element]).toJSON()).toMatchSnapshot()
     })
+
+    it('renders with NoPregrading when there are no scores', () => {
+      const props = {
+        ...defaultProps,
+        scores: _.pick(defaultScores, 'answerId', 'questionId'),
+      }
+      expect(renderWithContext(props, []).toJSON()).toMatchSnapshot()
+    })
+
+    it('renders with NoPregrading when there is pregrading data but no scores', () => {
+      const props = {
+        ...defaultProps,
+        scores: {
+          preGrading: { comment: 'comment' },
+          ..._.pick(defaultScores, 'answerId', 'questionId'),
+        },
+      }
+      expect(renderWithContext(props, []).toJSON()).toMatchSnapshot()
+    })
+
+    it('renders without NoPregrading when pregrading score is 0', () => {
+      const props = {
+        ...defaultProps,
+        scores: {
+          pregrading: { score: 0 },
+          ..._.pick(defaultScores, 'answerId', 'questionId'),
+        },
+      }
+      expect(renderWithContext(props, []).toJSON()).toMatchSnapshot()
+    })
+
+    it('renders without NoPregrading when there are scores', () => {
+      const props = {
+        ...defaultProps,
+        scores: _.pick(defaultScores, 'answerId', 'questionId', 'pregrading', 'censoring'),
+      }
+      expect(renderWithContext(props, []).toJSON()).toMatchSnapshot()
+    })
   })
 
   describe('sv-FI', () => {

--- a/packages/core/__tests__/results/__snapshots__/ResultsExamQuestionManualScore.test.tsx.snap
+++ b/packages/core/__tests__/results/__snapshots__/ResultsExamQuestionManualScore.test.tsx.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<ResultsExamQuestionManualScore /> fi-FI renders with NoPregrading when there are no scores 1`] = `
+<div
+  className="e-result-scorecount e-float-right e-mrg-b-1"
+>
+  <span
+    className="e-result-scorecount-empty"
+  />
+   / 6 
+   p.
+</div>
+`;
+
+exports[`<ResultsExamQuestionManualScore /> fi-FI renders with NoPregrading when there is pregrading data but no scores 1`] = `
+<div
+  className="e-result-scorecount e-float-right e-mrg-b-1"
+>
+  <span
+    className="e-result-scorecount-empty"
+  />
+   / 6 
+   p.
+</div>
+`;
+
 exports[`<ResultsExamQuestionManualScore /> fi-FI renders with displayNumber where there are more than one answer 1`] = `
 <div
   className="e-result-scorecount e-float-right e-mrg-b-1"
@@ -244,6 +268,129 @@ exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading, censo
     >
       4
       
+       p.
+    </span>
+    <span
+      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+    >
+      SE3
+    </span>
+    <span
+      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+    >
+      3.s
+    </span>
+  </div>
+  <div
+    className="e-color-grey e-font-size-xs"
+  >
+    <span
+      className="e-mrg-r-1 e-nowrap e-nowrap"
+    >
+      3
+      
+       p.
+    </span>
+    <span
+      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+    >
+      SE2
+    </span>
+    <span
+      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+    >
+      2.s
+    </span>
+  </div>
+  <div
+    className="e-color-grey e-font-size-xs"
+  >
+    <span
+      className="e-mrg-r-1 e-nowrap e-nowrap"
+    >
+      2
+      
+       p.
+    </span>
+    <span
+      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+    >
+      SE1
+    </span>
+    <span
+      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+    >
+      1.s
+    </span>
+  </div>
+  <div
+    className="e-color-grey e-font-size-xs"
+  >
+    <span
+      className="e-mrg-r-1 e-nowrap e-nowrap"
+    >
+      1
+      
+       p.
+    </span>
+    <span
+      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+    >
+      
+    </span>
+    <span
+      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+    >
+      va
+    </span>
+  </div>
+</div>
+`;
+
+exports[`<ResultsExamQuestionManualScore /> fi-FI renders without NoPregrading when pregrading score is 0 1`] = `
+<div
+  className="e-result-scorecount e-float-right e-mrg-b-1"
+>
+  <div
+    className="e-color-black"
+  >
+    <span
+      className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+    >
+      <b>
+        0
+      </b>
+       / 6
+       p.
+    </span>
+    <span
+      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+    >
+      
+    </span>
+    <span
+      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+    >
+      va
+    </span>
+  </div>
+</div>
+`;
+
+exports[`<ResultsExamQuestionManualScore /> fi-FI renders without NoPregrading when there are scores 1`] = `
+<div
+  className="e-result-scorecount e-float-right e-mrg-b-1"
+>
+  <div
+    className="e-color-black"
+  >
+    <span
+      className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+    >
+      <b>
+        4
+      </b>
+       / 6
        p.
     </span>
     <span

--- a/packages/core/src/components/results/ResultsExamQuestionManualScore.tsx
+++ b/packages/core/src/components/results/ResultsExamQuestionManualScore.tsx
@@ -23,14 +23,15 @@ function ResultsExamQuestionManualScore({ scores, maxScore, displayNumber }: Res
   const shortCode = scores?.censoring?.nonAnswerDetails?.shortCode
   return (
     <ResultsExamQuestionScoresContainer {...containerProps}>
-      {scores?.pregrading?.score == null && (!scores?.censoring || scores?.censoring?.scores.length === 0) && (
-        <NoPregrading maxScore={maxScore} />
-      )}
+      {noPregradingOrCensoringScore(scores) && <NoPregrading maxScore={maxScore} />}
       {scores && renderNormalizedScores(scores, maxScore)}
       {shortCode && <NonAnswer shortCode={shortCode} />}
     </ResultsExamQuestionScoresContainer>
   )
 }
+
+const noPregradingOrCensoringScore = (scores: Score | undefined): boolean =>
+  scores?.pregrading?.score == null && (!scores?.censoring || scores?.censoring?.scores.length === 0)
 
 function renderNormalizedScores(scores: Score, maxScore?: number) {
   const normalizedScores = [


### PR DESCRIPTION
Yksikkötestejä Eeron pyynnöstä ResultsExamQuestionManualScore-komponentille, kun ehdollisessa renderöinnissä oli aikaisemmin bugeja. Huom tuntuu näin jälkikäteen vähän mielivaltaiselta testisetiltä, milloin ja miten näitä pitäisi luoda. Epävarma olo asiasta.