### PR TITLE
Temp/fix pdf page flow on annotations

### DIFF
--- a/packages/core/__tests__/results/__snapshots__/ResultsExamQuestionAutoScore.test.tsx.snap
+++ b/packages/core/__tests__/results/__snapshots__/ResultsExamQuestionAutoScore.test.tsx.snap
@@ -2,47 +2,59 @@
 
 exports[`<ResultsExamQuestionAutoScore /> renders displayNumber number when there are more than one answer 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
-  <sup
-    className="e-result-scorecount-sup e-mrg-r-1"
+  <div
+    className="e-result-scorecount-border-wrap"
   >
-    1
-  </sup>
-  <b>
-    1
-  </b>
-   
-  / 3 
-   
-   p.
+    <sup
+      className="e-result-scorecount-sup e-mrg-r-1"
+    >
+      1
+    </sup>
+    <b>
+      1
+    </b>
+     
+    / 3 
+     
+     p.
+  </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionAutoScore /> renders with score 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
-  <b>
-    1
-  </b>
-   
-  / 3 
-   
-   p.
+  <div
+    className="e-result-scorecount-border-wrap"
+  >
+    <b>
+      1
+    </b>
+     
+    / 3 
+     
+     p.
+  </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionAutoScore /> renders without score 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
   <div
-    className="e-result-scorecount-empty"
-  />
-   
-  / 3 
-   
-   p.
+    className="e-result-scorecount-border-wrap"
+  >
+    <div
+      className="e-result-scorecount-empty"
+    />
+     
+    / 3 
+     
+     p.
+  </div>
 </div>
 `;

--- a/packages/core/__tests__/results/__snapshots__/ResultsExamQuestionManualScore.test.tsx.snap
+++ b/packages/core/__tests__/results/__snapshots__/ResultsExamQuestionManualScore.test.tsx.snap
@@ -2,596 +2,640 @@
 
 exports[`<ResultsExamQuestionManualScore /> fi-FI renders with NoPregrading when there are no scores 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
-  <span
-    className="e-result-scorecount-empty"
-  />
-   / 6 
-   p.
+  <div
+    className="e-result-scorecount-border-wrap"
+  >
+    <span
+      className="e-result-scorecount-empty"
+    />
+     / 6 
+     p.
+  </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionManualScore /> fi-FI renders with NoPregrading when there is pregrading data but no scores 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
-  <span
-    className="e-result-scorecount-empty"
-  />
-   / 6 
-   p.
+  <div
+    className="e-result-scorecount-border-wrap"
+  >
+    <span
+      className="e-result-scorecount-empty"
+    />
+     / 6 
+     p.
+  </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionManualScore /> fi-FI renders with displayNumber where there are more than one answer 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
-  <sup
-    className="e-result-scorecount-sup e-mrg-r-1"
-  >
-    1
-  </sup>
   <div
-    className="e-color-black"
+    className="e-result-scorecount-border-wrap"
   >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+    <sup
+      className="e-result-scorecount-sup e-mrg-r-1"
     >
-      <b>
-        1
-      </b>
-       / 6
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      1
+    </sup>
+    <div
+      className="e-color-black"
     >
-      
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      va
-    </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+      >
+        <b>
+          1
+        </b>
+         / 6
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        va
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading and one censor scores 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
   <div
-    className="e-color-black"
+    className="e-result-scorecount-border-wrap"
   >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+    <div
+      className="e-color-black"
     >
-      <b>
-        4
-      </b>
-       / 6
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+      >
+        <b>
+          4
+        </b>
+         / 6
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE3
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        1.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      SE3
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      1.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
-    >
-      1
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      va
-    </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        1
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        va
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading and three censor scores 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
   <div
-    className="e-color-black"
+    className="e-result-scorecount-border-wrap"
   >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+    <div
+      className="e-color-black"
     >
-      <b>
-        4
-      </b>
-       / 6
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+      >
+        <b>
+          4
+        </b>
+         / 6
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE3
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        3.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      SE3
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        3
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE2
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        2.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      3.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        2
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE1
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        1.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      3
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      SE2
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      2.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
-    >
-      2
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      SE1
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      1.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
-    >
-      1
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      va
-    </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        1
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        va
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading score 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
   <div
-    className="e-color-black"
+    className="e-result-scorecount-border-wrap"
   >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+    <div
+      className="e-color-black"
     >
-      <b>
-        1
-      </b>
-       / 6
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      va
-    </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+      >
+        <b>
+          1
+        </b>
+         / 6
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        va
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionManualScore /> fi-FI renders with pregrading, censor and inspection scores 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
   <div
-    className="e-color-black"
+    className="e-result-scorecount-border-wrap"
   >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+    <div
+      className="e-color-black"
     >
-      <b>
-        5
-      </b>
-       / 6
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+      >
+        <b>
+          5
+        </b>
+         / 6
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        IN1, IN2
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        ta
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      IN1, IN2
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        4
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE3
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        3.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      ta
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        3
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE2
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        2.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      4
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        2
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE1
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        1.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      SE3
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      3.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
-    >
-      3
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      SE2
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      2.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
-    >
-      2
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      SE1
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      1.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
-    >
-      1
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      va
-    </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        1
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        va
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionManualScore /> fi-FI renders without NoPregrading when pregrading score is 0 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
   <div
-    className="e-color-black"
+    className="e-result-scorecount-border-wrap"
   >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+    <div
+      className="e-color-black"
     >
-      <b>
-        0
-      </b>
-       / 6
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      va
-    </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+      >
+        <b>
+          0
+        </b>
+         / 6
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        va
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionManualScore /> fi-FI renders without NoPregrading when there are scores 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
   <div
-    className="e-color-black"
+    className="e-result-scorecount-border-wrap"
   >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+    <div
+      className="e-color-black"
     >
-      <b>
-        4
-      </b>
-       / 6
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+      >
+        <b>
+          4
+        </b>
+         / 6
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE3
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        3.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      SE3
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        3
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE2
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        2.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      3.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        2
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE1
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        1.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      3
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      SE2
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      2.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
-    >
-      2
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      SE1
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      1.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
-    >
-      1
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      va
-    </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        1
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        va
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionManualScore /> fi-FI renders without score 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
-  <span
-    className="e-result-scorecount-empty"
-  />
-   / 6 
-   p.
+  <div
+    className="e-result-scorecount-border-wrap"
+  >
+    <span
+      className="e-result-scorecount-empty"
+    />
+     / 6 
+     p.
+  </div>
 </div>
 `;
 
 exports[`<ResultsExamQuestionManualScore /> sv-FI renders with pregrading, censor and inspection scores 1`] = `
 <div
-  className="e-result-scorecount e-float-right e-mrg-b-1"
+  className="e-result-scorecount e-float-right"
 >
   <div
-    className="e-color-black"
+    className="e-result-scorecount-border-wrap"
   >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+    <div
+      className="e-color-black"
     >
-      <b>
-        5
-      </b>
-       / 6
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap e-font-size-m"
+      >
+        <b>
+          5
+        </b>
+         / 6
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        IN1, IN2
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        ta
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      IN1, IN2
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        4
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE3
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        3.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      ta
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        3
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE2
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        2.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      4
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        2
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        SE1
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        1.s
+      </span>
+    </div>
+    <div
+      className="e-color-grey e-font-size-xs"
     >
-      SE3
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      3.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
-    >
-      3
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      SE2
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      2.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
-    >
-      2
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      SE1
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      1.s
-    </span>
-  </div>
-  <div
-    className="e-color-grey e-font-size-xs"
-  >
-    <span
-      className="e-mrg-r-1 e-nowrap e-nowrap"
-    >
-      1
-      
-       p.
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
-    >
-      
-    </span>
-    <span
-      className="e-mrg-r-1 e-nowrap e-mrg-r-0"
-    >
-      va
-    </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-nowrap"
+      >
+        1
+        
+         p.
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-result-scorecount-shortcode"
+      >
+        
+      </span>
+      <span
+        className="e-mrg-r-1 e-nowrap e-mrg-r-0"
+      >
+        va
+      </span>
+    </div>
   </div>
 </div>
 `;

--- a/packages/core/src/components/results/Results.less
+++ b/packages/core/src/components/results/Results.less
@@ -35,7 +35,11 @@
   border-bottom: 2px solid #333;
 }
 
-// If several questions are on same row, scores overlap next question. Hack to prevent it.
 table td .e-result-scorecount {
+  width: 8rem;
+  height: auto;
+  margin-bottom: 0.5rem;
+
+  // If several questions are on same row, scores overlap next question. Hack to prevent it.
   margin-right: 0;
 }

--- a/packages/core/src/components/results/Results.less
+++ b/packages/core/src/components/results/Results.less
@@ -1,11 +1,17 @@
 .e-result-scorecount {
-  clear: right;
-  margin-right: -9rem;
-  width: 8rem;
-  padding-left: 1.5rem;
-  border-left: 1px solid #aaa;
   position: relative;
+  margin: 0;
+  height: 0;
+  overflow: visible;
+  clear: right;
+  transform: translateX(calc(100% + 1rem));
+
+  .e-result-scorecount-border-wrap {
+    border-left: 1px solid #aaa;
+    padding-left: 1.5rem;
+  }
 }
+
 .e-exam .e-result-scorecount-sup {
   position: absolute;
   left: 0.25rem;

--- a/packages/core/src/components/results/Results.less
+++ b/packages/core/src/components/results/Results.less
@@ -2,9 +2,12 @@
   clear: right;
   margin-right: -9rem;
   width: 8rem;
-  padding-left: 1.5rem;
-  border-left: 1px solid #aaa;
   position: relative;
+
+  .e-result-scorecount-border-wrap {
+    border-left: 1px solid #aaa;
+    padding-left: 1.5rem;
+  }
 }
 .e-exam .e-result-scorecount-sup {
   position: absolute;

--- a/packages/core/src/components/results/Results.less
+++ b/packages/core/src/components/results/Results.less
@@ -1,10 +1,12 @@
 .e-result-scorecount {
   position: relative;
+  left: 1rem;
   margin: 0;
   height: 0;
+  width: 0;
   overflow: visible;
   clear: right;
-  transform: translateX(calc(100% + 1rem));
+  white-space: nowrap;
 
   .e-result-scorecount-border-wrap {
     border-left: 1px solid #aaa;

--- a/packages/core/src/components/results/Results.less
+++ b/packages/core/src/components/results/Results.less
@@ -3,12 +3,13 @@
   margin-right: -9rem;
   width: 8rem;
   position: relative;
-
-  .e-result-scorecount-border-wrap {
-    border-left: 1px solid #aaa;
-    padding-left: 1.5rem;
-  }
 }
+
+.e-result-scorecount-border-wrap {
+  border-left: 1px solid @colors[grey];
+  padding-left: 1.5rem;
+}
+
 .e-exam .e-result-scorecount-sup {
   position: absolute;
   left: 0.25rem;
@@ -17,6 +18,7 @@
   text-align: right;
   min-width: 1rem;
 }
+
 .e-results-section-wrapper {
   padding-right: 9rem;
 }

--- a/packages/core/src/components/results/Results.less
+++ b/packages/core/src/components/results/Results.less
@@ -10,6 +10,21 @@
   padding-left: 1.5rem;
 }
 
+// Special rendering for multi-line and rich-text answer scores. The pdf rendering
+// with annotations might break because the score component affects
+// the flow of the elements in an annotated rich-text answer, which might put the overlayed
+// annotation elements out-of-sync on page breaks.
+.e-result-scorecount-multiline-answer {
+  position: relative;
+  left: 1rem;
+  margin: 0;
+  height: 0;
+  width: 0;
+  overflow: visible;
+  clear: right;
+  white-space: nowrap;
+}
+
 .e-exam .e-result-scorecount-sup {
   position: absolute;
   left: 0.25rem;

--- a/packages/core/src/components/results/Results.less
+++ b/packages/core/src/components/results/Results.less
@@ -1,19 +1,11 @@
 .e-result-scorecount {
-  position: relative;
-  left: 1rem;
-  margin: 0;
-  height: 0;
-  width: 0;
-  overflow: visible;
   clear: right;
-  white-space: nowrap;
-
-  .e-result-scorecount-border-wrap {
-    border-left: 1px solid #aaa;
-    padding-left: 1.5rem;
-  }
+  margin-right: -9rem;
+  width: 8rem;
+  padding-left: 1.5rem;
+  border-left: 1px solid #aaa;
+  position: relative;
 }
-
 .e-exam .e-result-scorecount-sup {
   position: absolute;
   left: 0.25rem;
@@ -35,11 +27,7 @@
   border-bottom: 2px solid #333;
 }
 
+// If several questions are on same row, scores overlap next question. Hack to prevent it.
 table td .e-result-scorecount {
-  width: 8rem;
-  height: auto;
-  margin-bottom: 0.5rem;
-
-  // If several questions are on same row, scores overlap next question. Hack to prevent it.
   margin-right: 0;
 }

--- a/packages/core/src/components/results/ResultsExamQuestionManualScore.tsx
+++ b/packages/core/src/components/results/ResultsExamQuestionManualScore.tsx
@@ -9,6 +9,7 @@ export interface ResultsExamQuestionManualScoreProps {
   scores?: Score
   maxScore?: number
   displayNumber?: string
+  className?: string
 }
 
 interface NormalizedScore {
@@ -17,9 +18,14 @@ interface NormalizedScore {
   type: string
 }
 
-function ResultsExamQuestionManualScore({ scores, maxScore, displayNumber }: ResultsExamQuestionManualScoreProps) {
+function ResultsExamQuestionManualScore({
+  scores,
+  maxScore,
+  displayNumber,
+  className,
+}: ResultsExamQuestionManualScoreProps) {
   const { answers } = useContext(QuestionContext)
-  const containerProps = { answers, displayNumber }
+  const containerProps = { answers, displayNumber, className }
   const shortCode = scores?.censoring?.nonAnswerDetails?.shortCode
   return (
     <ResultsExamQuestionScoresContainer {...containerProps}>

--- a/packages/core/src/components/results/ResultsExamQuestionManualScore.tsx
+++ b/packages/core/src/components/results/ResultsExamQuestionManualScore.tsx
@@ -9,7 +9,7 @@ export interface ResultsExamQuestionManualScoreProps {
   scores?: Score
   maxScore?: number
   displayNumber?: string
-  className?: string
+  multilineAnswer?: boolean
 }
 
 interface NormalizedScore {
@@ -22,10 +22,10 @@ function ResultsExamQuestionManualScore({
   scores,
   maxScore,
   displayNumber,
-  className,
+  multilineAnswer,
 }: ResultsExamQuestionManualScoreProps) {
   const { answers } = useContext(QuestionContext)
-  const containerProps = { answers, displayNumber, className }
+  const containerProps = { answers, displayNumber, multilineAnswer }
   const shortCode = scores?.censoring?.nonAnswerDetails?.shortCode
   return (
     <ResultsExamQuestionScoresContainer {...containerProps}>

--- a/packages/core/src/components/results/ResultsExamQuestionScoresContainer.tsx
+++ b/packages/core/src/components/results/ResultsExamQuestionScoresContainer.tsx
@@ -10,9 +10,13 @@ function ResultsExamQuestionScoresContainer({
   children: React.ReactNode
 }) {
   return (
-    <div className="e-result-scorecount e-float-right e-mrg-b-1">
-      {answers.length > 1 && displayNumber && <sup className="e-result-scorecount-sup e-mrg-r-1">{displayNumber}</sup>}
-      {children}
+    <div className="e-result-scorecount e-float-right">
+      <div className="e-result-scorecount-border-wrap">
+        {answers.length > 1 && displayNumber && (
+          <sup className="e-result-scorecount-sup e-mrg-r-1">{displayNumber}</sup>
+        )}
+        {children}
+      </div>
     </div>
   )
 }

--- a/packages/core/src/components/results/ResultsExamQuestionScoresContainer.tsx
+++ b/packages/core/src/components/results/ResultsExamQuestionScoresContainer.tsx
@@ -5,15 +5,19 @@ function ResultsExamQuestionScoresContainer({
   answers,
   displayNumber,
   children,
-  className,
+  multilineAnswer,
 }: {
   answers: Element[]
   displayNumber?: string
   children: React.ReactNode
-  className?: string
+  multilineAnswer?: boolean
 }) {
   return (
-    <div className={classnames('e-result-scorecount', 'e-float-right', className)}>
+    <div
+      className={classnames('e-result-scorecount', 'e-float-right', {
+        'e-result-scorecount-multiline-answer': multilineAnswer,
+      })}
+    >
       <div className="e-result-scorecount-border-wrap">
         {answers.length > 1 && displayNumber && (
           <sup className="e-result-scorecount-sup e-mrg-r-1">{displayNumber}</sup>

--- a/packages/core/src/components/results/ResultsExamQuestionScoresContainer.tsx
+++ b/packages/core/src/components/results/ResultsExamQuestionScoresContainer.tsx
@@ -1,16 +1,19 @@
 import React from 'react'
+import classnames from 'classnames'
 
 function ResultsExamQuestionScoresContainer({
   answers,
   displayNumber,
   children,
+  className,
 }: {
   answers: Element[]
   displayNumber?: string
   children: React.ReactNode
+  className?: string
 }) {
   return (
-    <div className="e-result-scorecount e-float-right">
+    <div className={classnames('e-result-scorecount', 'e-float-right', className)}>
       <div className="e-result-scorecount-border-wrap">
         {answers.length > 1 && displayNumber && (
           <sup className="e-result-scorecount-sup e-mrg-r-1">{displayNumber}</sup>

--- a/packages/core/src/components/results/ResultsTextAnswer.less
+++ b/packages/core/src/components/results/ResultsTextAnswer.less
@@ -7,7 +7,7 @@
 
 // Special rendering for multi-line and rich-text answer scores. The pdf rendering
 // with annotations might break because the score component affects
-// the flow of the elements in the rich-text answer which might put the overlayed
+// the flow of the elements in an annotated rich-text answer, which might put the overlayed
 // annotation elements out-of-sync on page breaks.
 .e-multiline-results-text-answer-score {
   position: relative;

--- a/packages/core/src/components/results/ResultsTextAnswer.less
+++ b/packages/core/src/components/results/ResultsTextAnswer.less
@@ -4,23 +4,3 @@
   margin-bottom: 0.5rem;
   word-break: break-word;
 }
-
-// Special rendering for multi-line and rich-text answer scores. The pdf rendering
-// with annotations might break because the score component affects
-// the flow of the elements in an annotated rich-text answer, which might put the overlayed
-// annotation elements out-of-sync on page breaks.
-.e-multiline-results-text-answer-score {
-  position: relative;
-  left: 1rem;
-  margin: 0;
-  height: 0;
-  width: 0;
-  overflow: visible;
-  clear: right;
-  white-space: nowrap;
-
-  .e-result-scorecount-border-wrap {
-    border-left: 1px solid #aaa;
-    padding-left: 1.5rem;
-  }
-}

--- a/packages/core/src/components/results/ResultsTextAnswer.less
+++ b/packages/core/src/components/results/ResultsTextAnswer.less
@@ -4,3 +4,23 @@
   margin-bottom: 0.5rem;
   word-break: break-word;
 }
+
+// Special rendering for multi-line and rich-text answer scores. The pdf rendering
+// with annotations might break because the score component affects
+// the flow of the elements in the rich-text answer which might put the overlayed
+// annotation elements out-of-sync on page breaks.
+.e-multiline-results-text-answer-score {
+  position: relative;
+  left: 1rem;
+  margin: 0;
+  height: 0;
+  width: 0;
+  overflow: visible;
+  clear: right;
+  white-space: nowrap;
+
+  .e-result-scorecount-border-wrap {
+    border-left: 1px solid #aaa;
+    padding-left: 1.5rem;
+  }
+}

--- a/packages/core/src/components/results/ResultsTextAnswer.tsx
+++ b/packages/core/src/components/results/ResultsTextAnswer.tsx
@@ -34,7 +34,11 @@ function ResultsTextAnswer({ element }: ExamComponentProps) {
       }
       return (
         <>
-          <ResultsExamQuestionManualScore scores={answerScores} maxScore={maxScore} />
+          <ResultsExamQuestionManualScore
+            className="e-multiline-results-text-answer-score"
+            scores={answerScores}
+            maxScore={maxScore}
+          />
           <div className="answer e-multiline-results-text-answer">
             <div className="answer-text-container">
               {type === 'rich-text' ? (

--- a/packages/core/src/components/results/ResultsTextAnswer.tsx
+++ b/packages/core/src/components/results/ResultsTextAnswer.tsx
@@ -34,11 +34,7 @@ function ResultsTextAnswer({ element }: ExamComponentProps) {
       }
       return (
         <>
-          <ResultsExamQuestionManualScore
-            className="e-multiline-results-text-answer-score"
-            scores={answerScores}
-            maxScore={maxScore}
-          />
+          <ResultsExamQuestionManualScore multilineAnswer={true} scores={answerScores} maxScore={maxScore} />
           <div className="answer e-multiline-results-text-answer">
             <div className="answer-text-container">
               {type === 'rich-text' ? (


### PR DESCRIPTION
Korjaa pdf rendauksen page break flow ongelman annotaatioiden kanssa asettamalla score-komponentin leveyden ja korkeuden nollaksi.

Loin pullarin katselmoitavaksi, vaikka fiksiä pitää vielä testata manuaalisesti ennen mergeä.