### PR TITLE
Use a separate lint step

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,7 +1,4 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: Build
+name: "CI"
 
 on:
   push:
@@ -10,14 +7,11 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -27,4 +21,13 @@ jobs:
     - run: yarn --frozen-lockfile
     - run: npm rebuild full-icu
     - run: yarn test -i --ci
-    - run: yarn lint
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: yarn --frozen-lockfile
+      - run: yarn lint


### PR DESCRIPTION
This shaves off ~20s off the build step and can be run concurrently, so
it makes the CI cycle a tiny bit faster.