### PR TITLE
Add 'lol' as an accepted answer for generated scoredTextAnswers

### DIFF
--- a/packages/generator/src/generateExamOptions.ts
+++ b/packages/generator/src/generateExamOptions.ts
@@ -60,6 +60,11 @@ export function scoredTextAnswer(options?: Partial<GenerateScoredTextAnswerOptio
         text: 'Oikea vaihtoehto',
         score: 3,
       },
+      // The legacy exam generator expects this to be the correct answer. (ノಠ益ಠ)ノ彡┻━┻
+      {
+        text: 'lol',
+        score: 3,
+      },
     ],
     ...options,
   }


### PR DESCRIPTION
This makes it possible to use the same answer generator backend for old and new exams in integration tests.