### PR TITLE
Fix most of our React's descendant warnings

### DIFF
--- a/packages/core/src/components/DropdownAnswer.tsx
+++ b/packages/core/src/components/DropdownAnswer.tsx
@@ -88,17 +88,17 @@ function DropdownAnswer({ element, renderChildNodes, saveAnswer, answer }: Dropd
           selectedItem,
         }) => (
           <span className={classNames('e-dropdown-answer e-normal')} data-question-id={questionId}>
-            <div
-              className={classNames('e-dropdown-answer__toggle-button e-columns', {
+            <span
+              className={classNames('e-dropdown-answer__toggle-button e-block e-columns', {
                 'e-dropdown-answer__toggle-button--open': isOpen,
               })}
               tabIndex="0"
               {...getToggleButtonProps()}
             >
               <span className="e-dropdown-answer__label e-column e-pad-l-1 e-pad-r-4" {...getLabelProps()}>
-                <div className="e-ellipsis" ref={labelRef}>
+                <span className="e-ellipsis e-block" ref={labelRef}>
                   {selectedItem ? renderChildNodes(selectedItem) : NBSP}
-                </div>
+                </span>
               </span>
               <span
                 className={classNames(
@@ -107,8 +107,8 @@ function DropdownAnswer({ element, renderChildNodes, saveAnswer, answer }: Dropd
               >
                 <FontAwesomeIcon icon={isOpen ? faChevronUp : faChevronDown} />
               </span>
-            </div>
-            <div
+            </span>
+            <span
               {...getMenuProps(
                 {
                   className: classNames('e-dropdown-answer__menu', { 'e-dropdown-answer__menu--open': isOpen }),
@@ -118,8 +118,8 @@ function DropdownAnswer({ element, renderChildNodes, saveAnswer, answer }: Dropd
               )}
             >
               {items.map((item, i) => (
-                <div
-                  className={classNames('e-dropdown-answer__menu-item e-pad-l-1 e-pad-r-4', {
+                <span
+                  className={classNames('e-dropdown-answer__menu-item e-block e-pad-l-1 e-pad-r-4', {
                     'e-dropdown-answer__menu-item--selected': item === selectedItem,
                     'e-bg-color-off-white': highlightedIndex !== i,
                     'e-bg-color-lighterblue': highlightedIndex === i,
@@ -131,12 +131,12 @@ function DropdownAnswer({ element, renderChildNodes, saveAnswer, answer }: Dropd
                   })}
                 >
                   {/* Use a wrapper element to exclude menu item padding when calculating the scroll width. */}
-                  <div className={classNames('e-dropdown-answer__menu-item-inner', { 'e-nowrap': measuring })}>
+                  <span className={classNames('e-dropdown-answer__menu-item-inner e-block', { 'e-nowrap': measuring })}>
                     {item ? renderChildNodes(item) : NBSP}
-                  </div>
-                </div>
+                  </span>
+                </span>
               ))}
-            </div>
+            </span>
           </span>
         )}
       </Downshift>

--- a/packages/core/src/components/ExamAttachment.tsx
+++ b/packages/core/src/components/ExamAttachment.tsx
@@ -4,9 +4,7 @@ import { ExamComponentProps } from '../createRenderChildNodes'
 
 function ExamAttachment({ element, renderChildNodes }: ExamComponentProps) {
   const { isExternal } = useContext(AttachmentContext)
-  return !isExternal ? (
-    <figure className="exam-attachment e-inline e-mrg-0 e-mrg-b-2">{renderChildNodes(element)}</figure>
-  ) : null
+  return !isExternal ? <span className="exam-attachment e-mrg-b-2">{renderChildNodes(element)}</span> : null
 }
 
 export default React.memo(withAttachmentContext(ExamAttachment))

--- a/packages/core/src/components/Formula.tsx
+++ b/packages/core/src/components/Formula.tsx
@@ -5,11 +5,9 @@ import { ExamComponentProps } from '../createRenderChildNodes'
 function Formula({ element, className }: ExamComponentProps) {
   const svg = element.getAttribute('svg')!
   const mml = element.getAttribute('mml')!
-  const mode = element.getAttribute('mode') || 'inline'
-  const Tag = mode === 'inline' ? 'span' : 'div'
 
   const html = svg + '<span class="e-screen-reader-only" role="presentation">' + mml + '</span>'
-  return <Tag className={classNames('e-formula', className)} dangerouslySetInnerHTML={{ __html: html }} />
+  return <span className={classNames('e-formula', className)} dangerouslySetInnerHTML={{ __html: html }} />
 }
 
 export default React.memo(Formula)

--- a/packages/core/src/components/ResponsiveMediaContainer.tsx
+++ b/packages/core/src/components/ResponsiveMediaContainer.tsx
@@ -29,7 +29,7 @@ export default function ResponsiveMediaContainer({
   const maxWidth = width + (bordered ? borderedPaddingAndBorderPx : 0)
 
   return (
-    <figure
+    <span
       className={classNames(
         'responsive-media-container',
         { 'responsive-media-container--bordered': bordered },
@@ -39,15 +39,15 @@ export default function ResponsiveMediaContainer({
         maxWidth,
       }}
     >
-      <div
+      <span
         className="responsive-media-container__inner"
         style={{
           paddingBottom,
         }}
       >
         {children}
-      </div>
-      {caption && <figcaption className="e-color-darkgrey e-mrg-t-1 e-font-size-s e-light">{caption}</figcaption>}
-    </figure>
+      </span>
+      {caption && <span className="e-color-darkgrey e-block e-mrg-t-1 e-font-size-s e-light">{caption}</span>}
+    </span>
   )
 }


### PR DESCRIPTION
Right now, we get quite a bit of the following kinds of errors to the
browser console:

   <div> cannot appear as a descendant of <p>

This is caused by invalid HTML in our exam structure, sometimes due to
incorrect XML (that the XML schema doesn't notice) and sometimes by
oversights in our React component.

This commit fixes most of the errors on the React side:

- Make ResponsiveMediaContainer a <span> instead of <figure>. The goal
is to allow <e:image> whereever were allow <img>, like inside <p> tags,
so we need to make sure that <e:image> is phrasing content. The previous
implementation used <figure> for hopes of better semantic compatibility,
but since <figure> is a flow element, it cannot be used inside a <p>.
- Same for <e:attachment>
- Make <e:figure mode="display"> a <span> instead of <div> for the same
reasons.

Fixing all of the errors in the XML side would require us to make the
XML schema stricter. This commit doesn't do that.