### PR TITLE
Improve CI performance

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,10 +1,10 @@
-name: "CI"
+name: 'CI'
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
@@ -13,22 +13,44 @@ jobs:
       matrix:
         node-version: [10.x, 12.x, 14.x]
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: yarn --frozen-lockfile
-    - run: npm rebuild full-icu
-    - run: yarn test -i --ci
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Restore cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+          key: ${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ matrix.node-version }}-
+
+      - run: yarn --frozen-lockfile
+      - run: npm rebuild full-icu
+      - run: yarn test -i --ci
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Use Node.js 12
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
+
+      - name: Restore cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+          key: ${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ matrix.node-version }}-
+
       - run: yarn --frozen-lockfile
       - run: yarn lint
       - run: yarn run bundlewatch --config .bundlewatch.config.js

--- a/jest.base.config.js
+++ b/jest.base.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   preset: 'ts-jest/presets/js-with-ts',
-  reporters: ['default', ['jest-junit', { outputName: 'jest-report.xml' }]],
+  globals: {'ts-jest': {isolatedModules: true}},
+  reporters: ['default', ['jest-junit', {outputName: 'jest-report.xml'}]],
   snapshotSerializers: ['jest-snapshot-serializer-raw'],
   testEnvironment: 'node',
-  testMatch: ['<rootDir>/__tests__/**/test*.ts?(x)', '<rootDir>/__tests__/**/*.test.ts?(x)']
+  testMatch: [
+    '<rootDir>/__tests__/**/test*.ts?(x)',
+    '<rootDir>/__tests__/**/*.test.ts?(x)'
+  ],
 }


### PR DESCRIPTION
Compare the runs of master and this branch:

`master` https://github.com/digabi/exam-engine/actions/runs/183211960
`feature/cache` https://github.com/digabi/exam-engine/actions/runs/183219412

You should see that the ` Run yarn --frozen-lockfile` and the `Run yarn test -i --ci` phases are dramatically faster.