### PR TITLE
Improve ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,8 @@
 module.exports = {
   extends: '@digabi/eslint-config',
-  parser: '@typescript-eslint/parser',
   parserOptions: {
     tsconfigRootDir: __dirname,
     project: './tsconfig.eslint.json',
   },
-  ignorePatterns: ['packages/*/dist', 'packages/*/*.js', 'packages/*/node_modules'],
+  ignorePatterns: ['packages/*/dist', '**/node_modules'],
 }

--- a/jest.base.config.js
+++ b/jest.base.config.js
@@ -1,11 +1,8 @@
 module.exports = {
   preset: 'ts-jest/presets/js-with-ts',
-  globals: {'ts-jest': {isolatedModules: true}},
-  reporters: ['default', ['jest-junit', {outputName: 'jest-report.xml'}]],
+  globals: { 'ts-jest': { isolatedModules: true } },
+  reporters: ['default', ['jest-junit', { outputName: 'jest-report.xml' }]],
   snapshotSerializers: ['jest-snapshot-serializer-raw'],
   testEnvironment: 'node',
-  testMatch: [
-    '<rootDir>/__tests__/**/test*.ts?(x)',
-    '<rootDir>/__tests__/**/*.test.ts?(x)'
-  ],
+  testMatch: ['<rootDir>/__tests__/**/test*.ts?(x)', '<rootDir>/__tests__/**/*.test.ts?(x)'],
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,5 @@ const base = require('./jest.base.config')
 
 module.exports = {
   ...base,
-  projects: ['<rootDir>/packages/*']
+  projects: ['<rootDir>/packages/*'],
 }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "build:analyze": "tsc --build && yarn workspace @digabi/exam-engine-core build:analyze && webpack-bundle-analyzer packages/core/stats.json packages/core/dist",
     "watch": "concurrently -n 'tsc,webpack' -c 'blue,green' 'tsc --build --watch' 'yarn workspace @digabi/exam-engine-core watch'",
     "lerna": "lerna",
-    "lint": "prettier packages/core/src/**/*.less --check && eslint packages --ext .js,.ts,.tsx --cache",
+    "lint": "prettier packages/core/src/**/*.less --check && eslint . --cache",
     "ee": "node packages/cli/dist/index.js",
     "test": "NODE_ICU_DATA=node_modules/full-icu jest",
     "prepare": "tsc --build --force && yarn workspace @digabi/exam-engine-core build"

--- a/packages/core/postcss.config.js
+++ b/packages/core/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: [require('postcss-preset-env')]
+  plugins: [require('postcss-preset-env')],
 }

--- a/packages/rendering/jest.config.js
+++ b/packages/rendering/jest.config.js
@@ -2,5 +2,5 @@ const base = require('../../jest.base.config')
 
 module.exports = {
   ...base,
-  setupFilesAfterEnv: ['./jest.setup.js']
+  setupFilesAfterEnv: ['./jest.setup.js'],
 }


### PR DESCRIPTION
- The --ext command line flag is not necessary in ESLint 7
- Lint all .js files in the project
- Do not use the TS parser for JS files
- Fix new lint errors