### PR TITLE
Use the full version of jQuery after all

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -8,7 +8,7 @@ module.exports = {
   files: [
     {
       path: 'packages/core/dist/main-bundle.js',
-      maxSize: '870KB',
+      maxSize: '887KB',
     },
     {
       path: 'packages/core/dist/main.css',

--- a/packages/core/webpack.config.js
+++ b/packages/core/webpack.config.js
@@ -20,11 +20,6 @@ module.exports = function () {
       globalObject: 'this',
     },
     plugins,
-    resolve: {
-      alias: {
-        jquery: 'jquery/dist/jquery.slim.min.js',
-      },
-    },
     module: {
       rules: [
         {


### PR DESCRIPTION
The slim version caused problems with mathquill, since it wants to
.animate() a few properties.