### PR TITLE
Remove <Results /> from main-bundle.js

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -8,7 +8,7 @@ module.exports = {
   files: [
     {
       path: 'packages/core/dist/main-bundle.js',
-      maxSize: '897KB',
+      maxSize: '860KB',
     },
     {
       path: 'packages/core/dist/main.css',

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "14.0.0",
+  "version": "14.1.0-alpha.0",
   "exact": true
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "clean-webpack-plugin": "^3.0.0",
     "concurrently": "^5.0.1",
     "css-loader": "^4.0.0",
+    "date-fns": "^2.8.1",
     "eslint": "^7.4.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-import": "^2.20.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-cli",
-  "version": "14.0.0",
+  "version": "14.1.0-alpha.0",
   "main": "index.js",
   "license": "EUPL-1.1",
   "files": [
@@ -10,8 +10,8 @@
     "ee": "./dist/index.js"
   },
   "dependencies": {
-    "@digabi/exam-engine-mastering": "14.0.0",
-    "@digabi/exam-engine-rendering": "14.0.0",
+    "@digabi/exam-engine-mastering": "14.1.0-alpha.0",
+    "@digabi/exam-engine-rendering": "14.1.0-alpha.0",
     "lodash": "^4.17.15",
     "ora": "^5.0.0",
     "uuid": "^8.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-core",
-  "version": "14.0.0",
+  "version": "14.1.0-alpha.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Matriculation Examination Board, Finland",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digabi/exam-engine-core",
   "version": "14.0.0",
-  "main": "dist/main-bundle.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.1",
@@ -18,35 +18,35 @@
     "watch": "webpack -p --watch",
     "prepublishOnly": "webpack -p && perl -pi -e 's|&&define.amd||' dist/main-bundle.js # Compatibility with our 💩 AMD loader"
   },
-  "peerDependencies": {
-    "react": "^16.8.0"
-  },
-  "devDependencies": {
+  "dependencies": {
     "@digabi/noto-sans": "^2.1.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.25",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.7",
     "baconjs": "1.x",
     "classnames": "^2.2.6",
-    "date-fns": "^2.8.1",
     "downshift": "^6.0.0",
     "fontfaceobserver": "^2.1.0",
     "i18next": "^19.0.1",
     "jquery": "^3.4.1",
     "lodash-es": "^4.17.15",
-    "react": "^16.12.0",
     "react-css-transition-replace": "^4.0.2",
-    "react-dom": "^16.12.0",
     "react-i18next": "^11.2.5",
     "react-redux": "^7.1.3",
-    "react-test-renderer": "^16.12.0",
     "redux": "^4.0.1",
     "redux-saga": "^1.1.3",
-    "redux-saga-test-plan": "^4.0.0-rc.3",
     "rich-text-editor": "^6.0.1",
     "sanitize-html": "^1.22.1",
     "typesafe-actions": "^5.1.0",
-    "utility-types": "^3.10.0",
+    "utility-types": "^3.10.0"
+  },
+  "devDependencies": {
+    "react": "^16.12.0",
+    "react-test-renderer": "^16.12.0",
+    "redux-saga-test-plan": "^4.0.0-rc.3",
     "webpack-bundle-analyzer": "^3.8.0"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,10 @@
-import '../src/css/main.less'
 import Attachments from './components/Attachments'
 import Exam from './components/Exam'
 import Results from './components/results/Results'
 import parseExam from './parser/parseExam'
 
 export { Attachments, Exam, Results, parseExam }
-export { ExamComponentProps } from './createRenderChildNodes'
+export type { ExamComponentProps } from './createRenderChildNodes'
 export * from './types/ExamAnswer'
 export * from './types/ExamServerAPI'
 export * from './types/GradingStructure'
@@ -15,5 +14,4 @@ export interface ExamBundle {
   Attachments: typeof Attachments
   Exam: typeof Exam
   parseExam: typeof parseExam
-  Results: typeof Results
 }

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,0 +1,9 @@
+import '../src/css/main.less'
+
+import Attachments from './components/Attachments'
+import Exam from './components/Exam'
+import parseExam from './parser/parseExam'
+
+// This is the entry point for the exam UMD bundle (main-bundle.js)
+
+export { Attachments, Exam, parseExam }

--- a/packages/core/webpack.config.js
+++ b/packages/core/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = function () {
   ]
 
   return {
-    entry: path.resolve(__dirname, 'dist/index.js'),
+    entry: path.resolve(__dirname, 'dist/main.js'),
     output: {
       path: path.resolve(__dirname, 'dist'),
       filename: 'main-bundle.js',

--- a/packages/exams/package.json
+++ b/packages/exams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-exams",
-  "version": "14.0.0",
+  "version": "14.1.0-alpha.0",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.1",
   "main": "dist/index.js",
@@ -12,6 +12,6 @@
     "prepublishOnly": "find . -name '*.xml' -print0 | xargs -0 -n 1 node ../cli/dist/index.js create-mex -p salasana -n nsa-scripts.zip -s security-codes.json -k \"${ANSWERS_PRIVATE_KEY:?must be set}\" "
   },
   "dependencies": {
-    "@digabi/exam-engine-mastering": "14.0.0"
+    "@digabi/exam-engine-mastering": "14.1.0-alpha.0"
   }
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-generator",
-  "version": "14.0.0",
+  "version": "14.1.0-alpha.0",
   "main": "dist/index.js",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.1",
@@ -8,7 +8,7 @@
     "dist"
   ],
   "dependencies": {
-    "@digabi/exam-engine-core": "14.0.0",
+    "@digabi/exam-engine-core": "14.1.0-alpha.0",
     "libxmljs2": "^0.26.0",
     "lodash": "^4.17.15"
   }

--- a/packages/mastering/package.json
+++ b/packages/mastering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-mastering",
-  "version": "14.0.0",
+  "version": "14.1.0-alpha.0",
   "main": "dist/index.js",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.1",
@@ -9,7 +9,7 @@
     "schema"
   ],
   "dependencies": {
-    "@digabi/exam-engine-core": "14.0.0",
+    "@digabi/exam-engine-core": "14.1.0-alpha.0",
     "ffprobe": "^1.1.0",
     "ffprobe-static": "^3.0.0",
     "glob": "^7.1.6",

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-rendering",
-  "version": "14.0.0",
+  "version": "14.1.0-alpha.0",
   "main": "./dist/index.js",
   "license": "EUPL-1.1",
   "files": [
@@ -13,8 +13,8 @@
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^7.8.7",
     "@babel/runtime": "^7.8.7",
-    "@digabi/exam-engine-core": "14.0.0",
-    "@digabi/exam-engine-mastering": "14.0.0",
+    "@digabi/exam-engine-core": "14.1.0-alpha.0",
+    "@digabi/exam-engine-mastering": "14.1.0-alpha.0",
     "babel-loader": "^8.0.6",
     "child-process-promise": "^2.2.1",
     "css-loader": "^4.0.0",

--- a/packages/rendering/src/preview.tsx
+++ b/packages/rendering/src/preview.tsx
@@ -1,4 +1,5 @@
-import { Attachments, Exam, Results, parseExam } from '@digabi/exam-engine-core'
+import { Attachments, Exam, parseExam } from '@digabi/exam-engine-core'
+import Results from '@digabi/exam-engine-core/dist/components/results/Results'
 import '@digabi/exam-engine-core/dist/main.css'
 import { MasteringResult } from '@digabi/exam-engine-mastering'
 import Cookie from 'js-cookie'


### PR DESCRIPTION
Right now, we ship also the code for viewing exam results in the exam
UMD bundle. This is of course wasteful, and it potentially is also a
security risk, since we are shipping extra code to the client.

As the project grows and we add new features (such as HVP), the pressure
for not including redundant code in the exam bundle also grows.

We tried splitting the bundles before, but it failed since
@digabi/exam-engine-core didn't declare its dependencies correctly, so
trying to import e.g. the Results component resulted in webpack
complaining about missing libraries.

As a fix, declare all runtime dependencies of @digabi/exam-engine-core
in its package.json and generate the UMD bundle from a separate main.ts
entrypoint.

This also improves the tree-shaking experience in downstream projects
that use e.g. the Results component, since code like

{ import Results, parseExam } from '@digabi/exam-engine-core'

will now import the code from an ES module instead of an UMD module, so
tree-shaking should be greatly improved.