### PR TITLE
Add optional argument to choose preview port

### DIFF
--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -1,7 +1,15 @@
 import { previewExam } from '@digabi/exam-engine-rendering'
 import { Ora } from 'ora'
 
-export default async function preview({ exam, port, spinner }: { exam: string; port: number; spinner: Ora }): Promise<string> {
+export default async function preview({
+  exam,
+  port,
+  spinner,
+}: {
+  exam: string
+  port: number
+  spinner: Ora
+}): Promise<string> {
   spinner.start(`Previewing ${exam}...`)
   const ctx = await previewExam(exam, { openFirefox: true, usePort: port })
   spinner.info(`Server is running at ${ctx.url}`)

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -7,11 +7,11 @@ export default async function preview({
   spinner,
 }: {
   exam: string
-  port: number
+  port?: number
   spinner: Ora
 }): Promise<string> {
   spinner.start(`Previewing ${exam}...`)
-  const ctx = await previewExam(exam, { openFirefox: true, usePort: port })
+  const ctx = await previewExam(exam, { openFirefox: true, port: port })
   spinner.info(`Server is running at ${ctx.url}`)
   return `Press Ctrl-C to stop`
 }

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -1,9 +1,9 @@
 import { previewExam } from '@digabi/exam-engine-rendering'
 import { Ora } from 'ora'
 
-export default async function preview({ exam, spinner }: { exam: string; spinner: Ora }): Promise<string> {
+export default async function preview({ exam, port, spinner }: { exam: string; port: number; spinner: Ora }): Promise<string> {
   spinner.start(`Previewing ${exam}...`)
-  const ctx = await previewExam(exam, { openFirefox: true })
+  const ctx = await previewExam(exam, { openFirefox: true, usePort: port })
   spinner.info(`Server is running at ${ctx.url}`)
   return `Press Ctrl-C to stop`
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,7 +21,20 @@ yargs
     },
     runCommand('./commands/new')
   )
-  .command(['preview [exam]', 'start'], 'Preview an exam', addExamArgs, runCommand('./commands/preview'))
+  .command(
+      ['preview [exam] [options]', 'start'],
+      'Preview an exam',
+      (argv) => {
+        addExamArgs(argv)
+        argv.option('port', {
+          alias: 'p',
+          description: 'The port to use in the preview HTTP server',
+          type: 'number',
+          default: 0,
+        })
+      },
+      runCommand('./commands/preview')
+  )
   .command(
     'create-transfer-zip [exam] [options]',
     'Create a transfer zip that can be imported to Oma Abitti',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,18 +22,18 @@ yargs
     runCommand('./commands/new')
   )
   .command(
-      ['preview [exam] [options]', 'start'],
-      'Preview an exam',
-      (argv) => {
-        addExamArgs(argv)
-        argv.option('port', {
-          alias: 'p',
-          description: 'The port to use in the preview HTTP server',
-          type: 'number',
-          default: 0,
-        })
-      },
-      runCommand('./commands/preview')
+    ['preview [exam] [options]', 'start'],
+    'Preview an exam',
+    (argv) => {
+      addExamArgs(argv)
+      argv.option('port', {
+        alias: 'p',
+        description: 'The port to use in the preview HTTP server',
+        type: 'number',
+        default: 0,
+      })
+    },
+    runCommand('./commands/preview')
   )
   .command(
     'create-transfer-zip [exam] [options]',

--- a/packages/rendering/src/getPreviewWebpackConfig.ts
+++ b/packages/rendering/src/getPreviewWebpackConfig.ts
@@ -39,7 +39,7 @@ export function getPreviewWebpackConfig(examFilename: string, options: Rendering
       quiet: true,
       contentBase: [path.resolve(__dirname, '../public'), path.dirname(examFilename)],
       historyApiFallback: true,
-      port: options.usePort ? options.usePort : 0,
+      port: options.port ?? 0,
       before: (app) => app.get('/math.svg', mathSvgResponse),
     },
   })

--- a/packages/rendering/src/getPreviewWebpackConfig.ts
+++ b/packages/rendering/src/getPreviewWebpackConfig.ts
@@ -39,7 +39,7 @@ export function getPreviewWebpackConfig(examFilename: string, options: Rendering
       quiet: true,
       contentBase: [path.resolve(__dirname, '../public'), path.dirname(examFilename)],
       historyApiFallback: true,
-      port: 0,
+      port: options.usePort ? options.usePort : 0,
       before: (app) => app.get('/math.svg', mathSvgResponse),
     },
   })

--- a/packages/rendering/src/index.ts
+++ b/packages/rendering/src/index.ts
@@ -1,7 +1,7 @@
 export interface RenderingOptions {
   casCountdownDurationSeconds?: number
   openFirefox?: boolean
-  usePort?: number
+  port?: number
 }
 
 export * from './createOfflineExam'

--- a/packages/rendering/src/index.ts
+++ b/packages/rendering/src/index.ts
@@ -1,6 +1,7 @@
 export interface RenderingOptions {
   casCountdownDurationSeconds?: number
   openFirefox?: boolean
+  usePort?: number
 }
 
 export * from './createOfflineExam'


### PR DESCRIPTION
This is related to #743 . I wanted to have an optional argument to `ee preview` which allows setting the port for the HTTP dev server.

Note that I have never written a single line of TypeScript before, and I'm also unable to test this locally. Thus, this is not too serious PR but possibly something to draw inspiration from. I'm just checking if it passes your CI.