### PR TITLE
Prevent double whitespace from table of contents and hints

### DIFF
--- a/packages/core/src/components/Hints.tsx
+++ b/packages/core/src/components/Hints.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames'
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { ExamComponentProps, RenderChildNodes } from '../createRenderChildNodes'
-import { findChildElement, getNumericAttribute, NBSP, queryAll } from '../dom-utils'
+import { findChildElement, getNumericAttribute, queryAll } from '../dom-utils'
 import { shortDisplayNumber } from '../shortDisplayNumber'
 import { AppState } from '../store'
 import { QuestionId } from '..'
@@ -54,9 +54,7 @@ function Hint({
       }}
       data-question-id={questionId}
     >
-      {shortDisplayNumber(displayNumber)}
-      {NBSP}
-      {renderChildNodes(hint)}
+      {shortDisplayNumber(displayNumber)} {renderChildNodes(hint)}
     </p>
   )
 }

--- a/packages/core/src/components/TableOfContents.tsx
+++ b/packages/core/src/components/TableOfContents.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import { Translation, useTranslation } from 'react-i18next'
 import { createRenderChildNodes, ExamComponentProps, RenderOptions } from '../createRenderChildNodes'
-import { findChildElement, NBSP, query, queryAncestors } from '../dom-utils'
+import { findChildElement, query, queryAncestors } from '../dom-utils'
 import { url } from '../url'
 import AnsweringInstructions from './AnsweringInstructions'
 import { CommonExamContext } from './CommonExamContext'
@@ -49,9 +49,7 @@ function TOCSectionTitle({ element, displayNumber, minAnswers, maxAnswers, child
       <header className="e-semibold" id={tocSectionTitleId(displayNumber)}>
         {element.hasChildNodes() && (
           <>
-            {numberOfSections > 1 && t('part', { displayNumber })}
-            {NBSP}
-            {renderChildNodes(element)}
+            {numberOfSections > 1 && t('part', { displayNumber })} {renderChildNodes(element)}
           </>
         )}
       </header>


### PR DESCRIPTION
Rendering e.g. <p>1.&nbsp; Something</p> causes two space characters
between "1." and "Something". So I suppose it's best not to use NBSP in
these cases at all. This does mean that there may be in theory a newline
between "1." and "Something", but I don't think it's something that we
have to worry about in practice.