### PR TITLE
Add support for file links in grading instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.8.0]
     steps:
       - uses: actions/checkout@v2.3.4
 

--- a/packages/core/src/components/grading-instructions/GradingInstructions.tsx
+++ b/packages/core/src/components/grading-instructions/GradingInstructions.tsx
@@ -8,6 +8,7 @@ import { I18nextProvider } from 'react-i18next'
 import Section from './Section'
 import SectionTitle from './SectionTitle'
 import Question from './Question'
+import File from '../shared/File'
 import ExamGradingInstruction from './ExamGradingInstruction'
 import AutogradedAnswer from './AutogradedAnswer'
 import Image from '../shared/Image'
@@ -27,6 +28,19 @@ import mkAttachmentLink from '../shared/AttachmentLink'
 import mkAttachmentLinks from '../shared/AttachmentLinks'
 import Recording from './Recording'
 
+const renderIfWithinGradingInstructionContent = renderIf(
+  ({ element }) =>
+    queryAncestors(element, [
+      'answer-grading-instruction',
+      'choice-answer-option',
+      'dropdown-answer-option',
+      'exam-grading-instruction',
+      'question-grading-instruction',
+      'hint',
+      'question-title',
+    ]) != null
+)
+
 const renderChildNodes = createRenderChildNodes({
   'accepted-answer': AutogradedAnswerOption,
   attachment: RenderExamElements,
@@ -39,28 +53,10 @@ const renderChildNodes = createRenderChildNodes({
   'dropdown-answer': AutogradedAnswer,
   'dropdown-answer-option': AutogradedAnswerOption,
   'external-material': RenderExamElements,
-  formula: renderIf(
-    ({ element }) =>
-      queryAncestors(element, [
-        'answer-grading-instruction',
-        'choice-answer',
-        'dropdown-answer',
-        'exam-grading-instruction',
-        'question-grading-instruction',
-        'question-title',
-      ]) != null
-  )(Formula),
+  file: renderIfWithinGradingInstructionContent(File),
+  formula: renderIfWithinGradingInstructionContent(Formula),
   hints: RenderExamElements,
-  image: renderIf(
-    ({ element }) =>
-      queryAncestors(element, [
-        'answer-grading-instruction',
-        'choice-answer',
-        'exam-grading-instruction',
-        'question-grading-instruction',
-        'scored-text-answer',
-      ]) != null
-  )(Image),
+  image: renderIfWithinGradingInstructionContent(Image),
   question: Question,
   'question-title': QuestionTitle,
   'question-grading-instruction': AnswerGradingInstruction,


### PR DESCRIPTION
This commit also unifies the different `renderIf(…)` blocks for
rendering images, formulas (and now) files.
