### PR TITLE
Upgrade Node 16 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.8.0]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@v2.3.4
 


### PR DESCRIPTION
The problems related to jest seem to have been fixed.
