### PR TITLE
Allow multiple exam-type attributes in localization

### DIFF
--- a/packages/mastering/__tests__/__snapshots__/testExamMastering.ts.snap
+++ b/packages/mastering/__tests__/__snapshots__/testExamMastering.ts.snap
@@ -26605,3 +26605,90 @@ exports[`Exam mastering supports arbitrarily nested questions: xml 1`] = `
 </e:exam>
 
 `;
+
+exports[`Exam mastering supports multiple exam-type attributes: hearing-impaired 1`] = `
+<?xml version="1.0" encoding="UTF-8"?>
+<e:exam xmlns:e="http://ylioppilastutkinto.fi/exam.xsd" xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ylioppilastutkinto.fi/exam.xsd https://abitti.dev/schema/exam.xsd" exam-schema-version="0.1" date="2020-01-01" exam-uuid="00000000-0000-0000-0000-000000000000" exam-lang="fi-FI" exam-type="hearing-impaired" max-score="0">
+  
+  <e:exam-instruction>
+    
+    <span>
+      Tekstiä kuulovammaisten kokeeseen.
+    </span>
+  </e:exam-instruction>
+  <e:table-of-contents/>
+  
+  <e:section display-number="2" max-score="0">
+    <e:section-title>Kirjalliset tehtävät</e:section-title>
+    <e:question exam-type="normal hearing-impaired" display-number="3" max-score="0">
+      <e:question-title>Kirjallinen tehtävä</e:question-title>
+    </e:question>
+    
+  </e:section>
+</e:exam>
+
+`;
+
+exports[`Exam mastering supports multiple exam-type attributes: normal 1`] = `
+<?xml version="1.0" encoding="UTF-8"?>
+<e:exam xmlns:e="http://ylioppilastutkinto.fi/exam.xsd" xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ylioppilastutkinto.fi/exam.xsd https://abitti.dev/schema/exam.xsd" exam-schema-version="0.1" date="2020-01-01" exam-uuid="00000000-0000-0000-0000-000000000000" exam-lang="fi-FI" exam-type="normal" max-score="0">
+  
+  <e:exam-instruction>
+    <span>
+      Tekstiä tavalliseen ja näkövammaisten kokeeseen.
+    </span>
+    
+  </e:exam-instruction>
+  <e:table-of-contents/>
+  <e:section display-number="1" max-score="0">
+    <e:section-title>Kuuntelutehtävät</e:section-title>
+    <e:question display-number="1" max-score="0">
+      <e:question-title>Kaikille yhteinen tehtävä</e:question-title>
+    </e:question>
+    <e:question exam-type="normal hearing-impaired" display-number="2" max-score="0">
+      <e:question-title>Kuuntelutehtävä</e:question-title>
+    </e:question>
+    
+  </e:section>
+  <e:section display-number="2" max-score="0">
+    <e:section-title>Kirjalliset tehtävät</e:section-title>
+    <e:question exam-type="normal hearing-impaired" display-number="3" max-score="0">
+      <e:question-title>Kirjallinen tehtävä</e:question-title>
+    </e:question>
+    
+  </e:section>
+</e:exam>
+
+`;
+
+exports[`Exam mastering supports multiple exam-type attributes: visually-impaired 1`] = `
+<?xml version="1.0" encoding="UTF-8"?>
+<e:exam xmlns:e="http://ylioppilastutkinto.fi/exam.xsd" xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ylioppilastutkinto.fi/exam.xsd https://abitti.dev/schema/exam.xsd" exam-schema-version="0.1" date="2020-01-01" exam-uuid="00000000-0000-0000-0000-000000000000" exam-lang="fi-FI" exam-type="visually-impaired" max-score="0">
+  
+  <e:exam-instruction>
+    <span>
+      Tekstiä tavalliseen ja näkövammaisten kokeeseen.
+    </span>
+    
+  </e:exam-instruction>
+  <e:table-of-contents/>
+  <e:section display-number="1" max-score="0">
+    <e:section-title>Kuuntelutehtävät</e:section-title>
+    <e:question display-number="1" max-score="0">
+      <e:question-title>Kaikille yhteinen tehtävä</e:question-title>
+    </e:question>
+    
+    <e:question exam-type="visually-impaired" display-number="2" max-score="0">
+      <e:question-title>Näkövammaisten korvaava kuuntelutehtävä</e:question-title>
+    </e:question>
+  </e:section>
+  <e:section display-number="2" max-score="0">
+    <e:section-title>Kirjalliset tehtävät</e:section-title>
+    
+    <e:question exam-type="visually-impaired" display-number="3" max-score="0">
+      <e:question-title>Näkövammaisten korvaava kirjallinen tehtävä</e:question-title>
+    </e:question>
+  </e:section>
+</e:exam>
+
+`;

--- a/packages/mastering/__tests__/fixtures/multiple_exam_types.xml
+++ b/packages/mastering/__tests__/fixtures/multiple_exam_types.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e:exam xmlns:e="http://ylioppilastutkinto.fi/exam.xsd" xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ylioppilastutkinto.fi/exam.xsd https://abitti.dev/schema/exam.xsd" exam-schema-version="0.3" date="2020-01-01">
+  <e:exam-versions>
+    <e:exam-version lang="fi-FI" exam-type="normal"/>
+    <e:exam-version lang="fi-FI" exam-type="visually-impaired"/>
+    <e:exam-version lang="fi-FI" exam-type="hearing-impaired"/>
+  </e:exam-versions>
+  <e:exam-instruction>
+    <e:localization exam-type="normal visually-impaired">
+      Tekstiä tavalliseen ja näkövammaisten kokeeseen.
+    </e:localization>
+    <e:localization exam-type="hearing-impaired">
+      Tekstiä kuulovammaisten kokeeseen.
+    </e:localization>
+  </e:exam-instruction>
+  <e:table-of-contents />
+  <e:section>
+    <e:section-title>Kuuntelutehtävät</e:section-title>
+    <e:question>
+      <e:question-title>Kaikille yhteinen tehtävä</e:question-title>
+    </e:question>
+    <e:question exam-type="normal hearing-impaired">
+      <e:question-title>Kuuntelutehtävä</e:question-title>
+    </e:question>
+    <e:question exam-type="visually-impaired">
+      <e:question-title>Näkövammaisten korvaava kuuntelutehtävä</e:question-title>
+    </e:question>
+  </e:section>
+  <e:section>
+    <e:section-title>Kirjalliset tehtävät</e:section-title>
+    <e:question exam-type="normal hearing-impaired">
+      <e:question-title>Kirjallinen tehtävä</e:question-title>
+    </e:question>
+    <e:question exam-type="visually-impaired">
+      <e:question-title>Näkövammaisten korvaava kirjallinen tehtävä</e:question-title>
+    </e:question>
+  </e:section>
+</e:exam>

--- a/packages/mastering/__tests__/testExamMastering.ts
+++ b/packages/mastering/__tests__/testExamMastering.ts
@@ -104,6 +104,15 @@ describe('Exam mastering', () => {
     ])
   })
 
+  it('supports multiple exam-type attributes', async () => {
+    const xml = await readFixture('multiple_exam_types.xml')
+    const masteringResults = await masterExam(xml, generateUuid, getMediaMetadata)
+
+    for (const masteringResult of masteringResults) {
+      expect(wrap(masteringResult.xml)).toMatchSnapshot(masteringResult.type)
+    }
+  })
+
   it('combines choice-answers and dropdown-answers to the same question in grading structure', async () => {
     const xml = generateExam({ sections: [{ questions: [question([choiceAnswer(), dropdownAnswer()])] }] })
     const [masteringResult] = await masterExam(xml, generateUuid, getMediaMetadata)

--- a/packages/mastering/schema/exam.xsd
+++ b/packages/mastering/schema/exam.xsd
@@ -49,7 +49,7 @@
         <xs:documentation>The exam language.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="exam-type" type="e:exam-type">
+    <xs:attribute name="exam-type" type="e:exam-type-list">
       <xs:annotation>
         <xs:documentation>
           You may want to create separate versions of the exam for students with disabilities. If not
@@ -178,6 +178,15 @@
           <xs:documentation>A version of the exam designed for hearing impaired students.</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="exam-type-list">
+    <xs:restriction>
+      <xs:simpleType>
+        <xs:list itemType="e:exam-type" />
+      </xs:simpleType>
+      <xs:minLength value="1"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/packages/mastering/src/mastering/index.ts
+++ b/packages/mastering/src/mastering/index.ts
@@ -499,7 +499,7 @@ function applyLocalizations(exam: Element, language: string, type: ExamType) {
   for (const localization of exam.find<Element>('//e:localization', ns)) {
     if (
       getAttribute('lang', localization, language) !== language ||
-      getAttribute('exam-type', localization, type) !== type ||
+      !getAttribute('exam-type', localization, type).includes(type) ||
       localization.childNodes().every((c) => c instanceof Text && c.text().trim().length === 0)
     ) {
       localization.remove()
@@ -509,7 +509,7 @@ function applyLocalizations(exam: Element, language: string, type: ExamType) {
   }
 
   exam
-    .find(`//e:*[(@lang and @lang!='${language}') or (@exam-type and @exam-type!='${type}')]`, ns)
+    .find(`//e:*[(@lang and @lang!='${language}') or (@exam-type and not(contains(@exam-type, '${type}')))]`, ns)
     .forEach((element) => element.remove())
 }
 


### PR DESCRIPTION
Before this change, localizing exams with three different exam versions
can be quite cumbersome. If we want to make an question that is used by
the `normal` and `hearing-impaired` exam versions and replace it with a
different question in the `visually-impaired` version, we had to do
something like

```
<e:question exam-type="normal">
   … question content…
</e:question>
<e:question exam-type="hearing-impaired">
   … copy-pasted question content…
</e:question>
<e:question exam-type="visually-impaired">
  …different question content…
</e:question>
```

With this change, the question content doesn't have to be copy-pasted
any more, since the exam can be coded as follows:

```
<e:question exam-type="normal hearing-impaired">
   … question content…
</e:question>
<e:question exam-type="visually-impaired">
  …different question content…
</e:question>
```
