### PR TITLE
Add labels to answer elements

### DIFF
--- a/packages/core/__tests__/results/AnnotationList.test.tsx
+++ b/packages/core/__tests__/results/AnnotationList.test.tsx
@@ -162,6 +162,7 @@ describe('<AnnotationList />', () => {
     maxScore: 2,
     level: 2,
     childQuestions: [],
+    questionLabelIds: '',
   }
 
   const resultsContextDefaults: ResultsContext = {

--- a/packages/core/__tests__/results/ResultsExamQuestionAutoScore.test.tsx
+++ b/packages/core/__tests__/results/ResultsExamQuestionAutoScore.test.tsx
@@ -48,6 +48,7 @@ describe('<QuestionAutoScore />', () => {
     maxScore: 2,
     level: 2,
     childQuestions: [],
+    questionLabelIds: '',
   }
 
   function renderWithContext(props: QuestionAutoScoreProps, answers: Element[]) {

--- a/packages/core/__tests__/results/ResultsExamQuestionManualScore.test.tsx
+++ b/packages/core/__tests__/results/ResultsExamQuestionManualScore.test.tsx
@@ -148,6 +148,7 @@ describe('<QuestionManualScore />', () => {
     maxScore: 2,
     level: 2,
     childQuestions: [],
+    questionLabelIds: '',
   }
 
   function renderWithContext(props: QuestionManualScoreProps, answers: Element[]) {

--- a/packages/core/src/components/context/QuestionContext.ts
+++ b/packages/core/src/components/context/QuestionContext.ts
@@ -2,6 +2,7 @@ import React from 'react'
 import { findChildElement, getNumericAttribute, parentElements, queryAll } from '../../dom-utils'
 import { withContext } from './withContext'
 import { ExamComponentProps } from '../../createRenderChildNodes'
+import { questionInstructionId, questionTitleId } from '../../ids'
 
 export interface QuestionContext {
   answers: Element[]
@@ -11,6 +12,7 @@ export interface QuestionContext {
   maxScore: number
   level: number
   childQuestions: Element[]
+  questionLabelIds: string
 }
 
 export const QuestionContext = React.createContext<QuestionContext>({} as QuestionContext)
@@ -20,14 +22,21 @@ export const withQuestionContext = withContext<QuestionContext, ExamComponentPro
   const answers = childQuestions.length
     ? []
     : queryAll(element, ['text-answer', 'scored-text-answer', 'dropdown-answer', 'choice-answer'], false)
+  const questionInstructions = queryAll(element, 'question-instruction', false)
+  const displayNumber = element.getAttribute('display-number')!
+  const questionLabelIds =
+    questionInstructions.length > 0
+      ? questionInstructions.map(questionInstructionId).join(' ')
+      : questionTitleId(displayNumber)
 
   return {
     answers,
-    displayNumber: element.getAttribute('display-number')!,
+    displayNumber,
     hasExternalMaterial: findChildElement(element, 'external-material') != null,
     maxAnswers: getNumericAttribute(element, 'max-answers'),
     maxScore: getNumericAttribute(element, 'max-score')!,
     level: parentElements(element, 'question').length,
     childQuestions,
+    questionLabelIds,
   }
 })

--- a/packages/core/src/components/exam/ChoiceAnswer.tsx
+++ b/packages/core/src/components/exam/ChoiceAnswer.tsx
@@ -1,11 +1,12 @@
 import classNames from 'classnames'
-import React from 'react'
+import React, { useContext } from 'react'
 import { connect } from 'react-redux'
 import { getNumericAttribute, mapChildElements, query } from '../../dom-utils'
 import { AppState } from '../../store'
 import * as actions from '../../store/answers/actions'
 import { ExamComponentProps } from '../../createRenderChildNodes'
 import { ChoiceAnswer as ChoiceAnswerT, QuestionId } from '../../types/ExamAnswer'
+import { QuestionContext } from '../context/QuestionContext'
 
 interface ChoiceAnswerOptionProps extends ExamComponentProps {
   questionId: QuestionId
@@ -78,6 +79,7 @@ interface ChoiceAnswerProps extends ExamComponentProps {
 }
 
 function ChoiceAnswer({ answer, saveAnswer, element, renderChildNodes }: ChoiceAnswerProps) {
+  const { questionLabelIds } = useContext(QuestionContext)
   const questionId = getNumericAttribute(element, 'question-id')!
   const direction = element.getAttribute('direction') || 'vertical'
   const className = element.getAttribute('class')
@@ -93,6 +95,8 @@ function ChoiceAnswer({ answer, saveAnswer, element, renderChildNodes }: ChoiceA
           'e-columns': direction === 'horizontal',
         })}
         data-question-id={questionId}
+        role="radiogroup"
+        aria-labelledby={questionLabelIds}
       >
         {mapChildElements(element, (childElement) => {
           const optionId = childElement.getAttribute('option-id')!

--- a/packages/core/src/components/exam/DropdownAnswer.tsx
+++ b/packages/core/src/components/exam/DropdownAnswer.tsx
@@ -65,7 +65,7 @@ function DropdownAnswer({ element, renderChildNodes, saveAnswer, answer }: Dropd
     })
   }
   const items: Item[] = [noAnswer, ...element.children]
-  const { answers } = useContext(QuestionContext)
+  const { answers, questionLabelIds } = useContext(QuestionContext)
   const { getItemProps, getMenuProps, getToggleButtonProps, highlightedIndex, isOpen, selectedItem } = useSelect({
     items,
     itemToString: (item) => (item ? item.textContent! : ''),
@@ -89,8 +89,7 @@ function DropdownAnswer({ element, renderChildNodes, saveAnswer, answer }: Dropd
           {...getToggleButtonProps(
             {
               'aria-describedby': scoreId,
-              // The label text is inside the button, so we don't want an aria-labelledby attribute.
-              'aria-labelledby': undefined,
+              'aria-labelledby': questionLabelIds,
             },
             { suppressRefError: !runningInBrowser }
           )}

--- a/packages/core/src/components/exam/QuestionInstruction.tsx
+++ b/packages/core/src/components/exam/QuestionInstruction.tsx
@@ -1,8 +1,14 @@
 import React from 'react'
 import { ExamComponentProps } from '../../createRenderChildNodes'
+import { questionInstructionId } from '../../ids'
 
 function QuestionInstruction({ element, renderChildNodes }: ExamComponentProps) {
-  return <div className="exam-question-instruction e-mrg-b-2">{renderChildNodes(element)}</div>
+  const id = questionInstructionId(element)
+  return (
+    <div className="exam-question-instruction e-mrg-b-2" id={id}>
+      {renderChildNodes(element)}
+    </div>
+  )
 }
 
 export default React.memo(QuestionInstruction)

--- a/packages/core/src/components/exam/QuestionTitle.tsx
+++ b/packages/core/src/components/exam/QuestionTitle.tsx
@@ -6,14 +6,16 @@ import { QuestionContext } from '../context/QuestionContext'
 import { Score } from '../shared/Score'
 import { ExamComponentProps } from '../../createRenderChildNodes'
 import { formatQuestionDisplayNumber } from '../../formatting'
+import { questionTitleId } from '../../ids'
 
 const QuestionTitle: React.FunctionComponent<ExamComponentProps> = ({ element, renderChildNodes }) => {
   const { displayNumber, maxScore, level, maxAnswers, childQuestions } = useContext(QuestionContext)
   const Tag = `h${Math.min(3 + level, 6)}` as 'h3' | 'h4' | 'h5' | 'h6'
+  const id = questionTitleId(displayNumber)
 
   return (
     <>
-      <Tag className={classNames('exam-question-title', { 'e-normal e-font-size-m': level > 0 })}>
+      <Tag id={id} className={classNames('exam-question-title', { 'e-normal e-font-size-m': level > 0 })}>
         <strong
           className={classNames('exam-question-title__display-number', {
             'exam-question-title__display-number--indented': level > 0,

--- a/packages/core/src/components/exam/RichTextAnswer.tsx
+++ b/packages/core/src/components/exam/RichTextAnswer.tsx
@@ -19,6 +19,7 @@ interface Props {
   onChange: (answerHTML: string, answerText: string) => void
   onError: (error: ScreenshotError) => void
   saveScreenshot: (screenshot: Blob) => Promise<string>
+  labelledBy: string
 }
 
 export default class RichTextAnswer extends React.PureComponent<Props> {
@@ -91,7 +92,7 @@ export default class RichTextAnswer extends React.PureComponent<Props> {
   }
 
   render(): React.ReactNode {
-    const { className, questionId, invalid } = this.props
+    const { className, questionId, invalid, labelledBy } = this.props
 
     return (
       <div
@@ -102,6 +103,7 @@ export default class RichTextAnswer extends React.PureComponent<Props> {
         aria-multiline="true"
         aria-invalid={invalid}
         tabIndex={0}
+        aria-labelledby={labelledBy}
       />
     )
   }

--- a/packages/core/src/components/exam/TextAnswer.tsx
+++ b/packages/core/src/components/exam/TextAnswer.tsx
@@ -1,15 +1,17 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { findChildElement } from '../../dom-utils'
 import { shortDisplayNumber } from '../../shortDisplayNumber'
 import TextAnswerInput from './internal/TextAnswerInput'
 import { ExamComponentProps } from '../../createRenderChildNodes'
 import { ScreenReaderOnly } from '../ScreenReaderOnly'
+import { QuestionContext } from '../context/QuestionContext'
 
 function TextAnswer(props: ExamComponentProps) {
   const { element, renderChildNodes } = props
+  const { questionLabelIds } = useContext(QuestionContext)
   const displayNumber = element.getAttribute('display-number')!
   const hint = findChildElement(element, 'hint')
-  const textAnswer = <TextAnswerInput {...props} />
+  const textAnswer = <TextAnswerInput {...{ ...props, labelledBy: questionLabelIds }} />
 
   return hint ? (
     <label className="e-nowrap">

--- a/packages/core/src/components/exam/TextAnswer.tsx
+++ b/packages/core/src/components/exam/TextAnswer.tsx
@@ -5,13 +5,17 @@ import TextAnswerInput from './internal/TextAnswerInput'
 import { ExamComponentProps } from '../../createRenderChildNodes'
 import { ScreenReaderOnly } from '../ScreenReaderOnly'
 import { QuestionContext } from '../context/QuestionContext'
+import { answerLengthInfoId } from '../../ids'
 
 function TextAnswer(props: ExamComponentProps) {
   const { element, renderChildNodes } = props
   const { questionLabelIds } = useContext(QuestionContext)
   const displayNumber = element.getAttribute('display-number')!
   const hint = findChildElement(element, 'hint')
-  const textAnswer = <TextAnswerInput {...{ ...props, labelledBy: questionLabelIds }} />
+  const labelledBy = element.hasAttribute('max-length')
+    ? questionLabelIds + ' ' + answerLengthInfoId(element)
+    : questionLabelIds
+  const textAnswer = <TextAnswerInput {...{ ...props, labelledBy }} />
 
   return hint ? (
     <label className="e-nowrap">

--- a/packages/core/src/components/exam/internal/TextAnswerInput.tsx
+++ b/packages/core/src/components/exam/internal/TextAnswerInput.tsx
@@ -11,7 +11,7 @@ import { ExamContext } from '../../context/ExamContext'
 import { QuestionContext } from '../../context/QuestionContext'
 import RichTextAnswer, { ScreenshotError } from '../RichTextAnswer'
 import { Score } from '../../shared/Score'
-import { answerScoreId } from '../../../ids'
+import { answerLengthInfoId, answerScoreId } from '../../../ids'
 import { AnswerTooLong } from '../../../validateAnswers'
 import AnswerLengthInfo from '../../shared/AnswerLengthInfo'
 
@@ -141,7 +141,7 @@ export class TextAnswerInput extends React.PureComponent<Props, State> {
       case 'rich-text':
         return (
           <>
-            {maxLength != null && <AnswerLengthInfo {...{ maxLength }} />}
+            {maxLength != null && <AnswerLengthInfo {...{ maxLength, id: answerLengthInfoId(element) }} />}
             <ExamContext.Consumer>
               {({ examServerApi }) => (
                 <RichTextAnswer

--- a/packages/core/src/components/exam/internal/TextAnswerInput.tsx
+++ b/packages/core/src/components/exam/internal/TextAnswerInput.tsx
@@ -25,6 +25,7 @@ interface Props extends ExamComponentProps {
   supportsAnswerHistory: boolean
   type: 'rich-text' | 'multi-line' | 'single-line'
   validationError?: AnswerTooLong
+  labelledBy: string
 }
 
 const borderWidthPx = 2
@@ -126,6 +127,7 @@ export class TextAnswerInput extends React.PureComponent<Props, State> {
       supportsAnswerHistory,
       type,
       validationError,
+      labelledBy,
     } = this.props
     const { screenshotError } = this.state
     const questionId = getNumericAttribute(element, 'question-id')
@@ -150,6 +152,7 @@ export class TextAnswerInput extends React.PureComponent<Props, State> {
                   onError={this.onError}
                   questionId={questionId!}
                   invalid={invalid}
+                  labelledBy={labelledBy}
                 />
               )}
             </ExamContext.Consumer>
@@ -179,6 +182,7 @@ export class TextAnswerInput extends React.PureComponent<Props, State> {
               ref={this.ref}
               data-question-id={questionId}
               aria-invalid={invalid}
+              aria-labelledby={labelledBy}
             />
             <AnswerToolbar
               {...{
@@ -207,6 +211,7 @@ export class TextAnswerInput extends React.PureComponent<Props, State> {
               ref={this.ref}
               data-question-id={questionId}
               aria-describedby={scoreId}
+              aria-labelledby={labelledBy}
             />
             <QuestionContext.Consumer>
               {({ answers }) => answers.length > 1 && <Score score={maxScore} size="inline" id={scoreId} />}

--- a/packages/core/src/components/shared/AnswerLengthInfo.tsx
+++ b/packages/core/src/components/shared/AnswerLengthInfo.tsx
@@ -2,10 +2,11 @@ import React from 'react'
 import { useExamTranslation } from '../../i18n'
 import NotificationIcon from '../NotificationIcon'
 
-const AnswerLengthInfo: React.FunctionComponent<{ maxLength: number }> = ({ maxLength }) => {
+const AnswerLengthInfo: React.FunctionComponent<{ maxLength: number; id?: string }> = ({ maxLength, id }) => {
   const { t } = useExamTranslation()
+
   return (
-    <p>
+    <p id={id} className="e-answer-length-info">
       <NotificationIcon />
       <em>{t('max-length-info', { count: maxLength })}</em>
     </p>

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -27,6 +27,8 @@ export const sectionTitleId = byDisplayNumber('section-title')
 
 export const questionTitleId = byDisplayNumber('question-title')
 
+export const questionInstructionId = byElementId('question-instruction')
+
 export const externalMaterialListTitleId = byElementId('external-material-list-title')
 
 export const tocSectionTitleId = byDisplayNumber('toc-section-title')

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -29,6 +29,8 @@ export const questionTitleId = byDisplayNumber('question-title')
 
 export const questionInstructionId = byElementId('question-instruction')
 
+export const answerLengthInfoId = byElementId('answer-length-info')
+
 export const externalMaterialListTitleId = byElementId('external-material-list-title')
 
 export const tocSectionTitleId = byDisplayNumber('toc-section-title')


### PR DESCRIPTION
Enable screen readers to provide better context when accessing input elements.
Use id of question instruction (if exists) and question title as label for answer
elements. Group choice answers together into a radio group for easier identification.
Add maximum length info text to text-answer labels.
