### PR TITLE
Improve the screen reader labeling of restricted audio

### DIFF
--- a/packages/core/src/components/shared/internal/RestrictedAudioPlayer.tsx
+++ b/packages/core/src/components/shared/internal/RestrictedAudioPlayer.tsx
@@ -24,10 +24,13 @@ function RestrictedAudioPlayer({
   const audioState = useSelector(getAudioState(src, restrictedAudioId))
   const durationRemaining = useSelector(getDurationRemaining(src, restrictedAudioId))
   const playbackTimesRemaining = useSelector(getPlaybackTimesRemaining(restrictedAudioId, times))
-  const { i18n, t } = useExamTranslation()
+  const { i18n } = useExamTranslation()
   const dispatch = useDispatch()
-  const disabled = audioState !== 'stopped' || playbackTimesRemaining === 0
+  const playing = audioState === 'playing'
+  const stopped = audioState === 'stopped'
+  const disabled = !stopped || playbackTimesRemaining === 0
   const remainingLabelId = `audio-remaining-${restrictedAudioId}`
+  const labels = playing ? [] : [remainingLabelId, labelId]
 
   return (
     <div
@@ -39,17 +42,16 @@ function RestrictedAudioPlayer({
     >
       <button
         className={classNames('restricted-audio-player__play e-column e-column--narrow', {
-          'restricted-audio-player__play--playing': audioState === 'playing',
+          'restricted-audio-player__play--playing': playing,
         })}
         disabled={disabled}
-        onClick={() => audioState === 'stopped' && dispatch(playAudio({ src, restrictedAudioId, duration }))}
-        aria-describedby={[remainingLabelId, labelId].join(' ')}
-        aria-label={t.raw('audio.play')}
+        onClick={() => stopped && dispatch(playAudio({ src, restrictedAudioId, duration }))}
+        aria-labelledby={labels.join(' ')}
       >
-        {audioState !== 'playing' && <FontAwesomeIcon icon={faPlay} fixedWidth />}
+        {!playing && <FontAwesomeIcon icon={faPlay} fixedWidth />}
       </button>
       <span className="restricted-audio-player__duration e-column e-text-right" id={remainingLabelId}>
-        {formatDuration(durationRemaining != null ? durationRemaining : duration)}
+        {formatDuration(durationRemaining ?? duration)}
       </span>
     </div>
   )

--- a/packages/core/src/i18n/fi-FI.ts
+++ b/packages/core/src/i18n/fi-FI.ts
@@ -24,9 +24,6 @@ export const fi_FI = {
   comment: 'Kommentti',
   points: '{{count}} p.',
   recording: 'Tallenne',
-  audio: {
-    play: 'Kuuntele äänite.',
-  },
   'audio-errors': {
     'already-accessed': 'Olet jo toistanut tämän äänitteen. Päivitä sivu.',
     'already-playing': 'Kuuntele äänite ensin loppuun.',

--- a/packages/core/src/i18n/sv-FI.ts
+++ b/packages/core/src/i18n/sv-FI.ts
@@ -13,9 +13,6 @@ export const sv_FI: Translations = {
   comment: 'Kommentar',
   points: '{{count}} p.',
   recording: 'Inspelningen',
-  audio: {
-    play: 'Lyssna på inspelningen.',
-  },
   'audio-errors': {
     'already-accessed': 'Du har redan spelat denna inspelning. Uppdatera sidan',
     'already-playing': 'Lyssna först inspelningen till slut.',


### PR DESCRIPTION
Instead of labeling the button with "Kuuntele äänite" and adding the
audio description as an aria-describedby, just use the audio description
as the label for the audio player button. With this change, a screen
reader user will hear something like this after focusing the button:

    00:10, Hören Sie den Abschnitt für die Frage 2.2., 1 kuuntelukerta jäljellä, painike

instead of

    Kuuntele äänite, painike, <...short break...> 00:10, Hören Sie den Abschnitt für die Frage 2.2., 1 kuuntelukerta jäljellä

It also hides the button description while the restricted audio is playing, so the screen reader doesn't try to read updates to the remaining time while the audio is playing.
