### PR TITLE
Fix choice answer bottom margin

### DIFF
--- a/packages/core/src/components/exam/ChoiceAnswer.tsx
+++ b/packages/core/src/components/exam/ChoiceAnswer.tsx
@@ -91,7 +91,7 @@ function ChoiceAnswer({ answer, saveAnswer, element, renderChildNodes }: ChoiceA
   return (
     <>
       <div
-        className={classNames('e-choice-answer', className, {
+        className={classNames('e-choice-answer e-mrg-b-4', className, {
           'e-columns': direction === 'horizontal',
         })}
         data-question-id={questionId}

--- a/packages/core/src/components/exam/ChoiceAnswer.tsx
+++ b/packages/core/src/components/exam/ChoiceAnswer.tsx
@@ -89,38 +89,36 @@ function ChoiceAnswer({ answer, saveAnswer, element, renderChildNodes }: ChoiceA
   }
 
   return (
-    <>
-      <div
-        className={classNames('e-choice-answer e-mrg-b-4', className, {
-          'e-columns': direction === 'horizontal',
-        })}
-        data-question-id={questionId}
-        role="radiogroup"
-        aria-labelledby={questionLabelIds}
-      >
-        {mapChildElements(element, (childElement) => {
-          const optionId = childElement.getAttribute('option-id')!
-          const isNoAnswer = childElement.getAttribute('type') === 'no-answer'
-          const value = isNoAnswer ? '' : optionId
-          const selected = answer != null && answer.value === value
+    <div
+      className={classNames('e-choice-answer e-mrg-b-4', className, {
+        'e-columns': direction === 'horizontal',
+      })}
+      data-question-id={questionId}
+      role="radiogroup"
+      aria-labelledby={questionLabelIds}
+    >
+      {mapChildElements(element, (childElement) => {
+        const optionId = childElement.getAttribute('option-id')!
+        const isNoAnswer = childElement.getAttribute('type') === 'no-answer'
+        const value = isNoAnswer ? '' : optionId
+        const selected = answer != null && answer.value === value
 
-          return (
-            <ChoiceAnswerOption
-              {...{
-                element: childElement,
-                onSelect,
-                renderChildNodes,
-                questionId,
-                key: optionId,
-                direction,
-                selected,
-                value,
-              }}
-            />
-          )
-        })}
-      </div>
-    </>
+        return (
+          <ChoiceAnswerOption
+            {...{
+              element: childElement,
+              onSelect,
+              renderChildNodes,
+              questionId,
+              key: optionId,
+              direction,
+              selected,
+              value,
+            }}
+          />
+        )
+      })}
+    </div>
   )
 }
 


### PR DESCRIPTION
When we removed AnswerToolbar from ChoiceAnswer in d755023b3e, we
accidentally removed the bottom-margin from ChoiceAnswer, since the
empty AnswerToolbar effectively provided 2 rem of bottom margin. Fix
this issue by adding an explicit 2 rem bottom-margin to ChoiceAnswer.
