### PR TITLE
Fix createMex hanging on Node 16

### DIFF
--- a/packages/mastering/src/createMex.ts
+++ b/packages/mastering/src/createMex.ts
@@ -147,7 +147,7 @@ function encryptAndSignFiles(
   }
   innerZipFile.end()
 
-  encryptAndSign(zipFile, filename, keyAndIv, answersPrivateKey, new Readable().wrap(innerZipFile.outputStream))
+  encryptAndSign(zipFile, filename, keyAndIv, answersPrivateKey, innerZipFile.outputStream as Readable)
 }
 
 function encryptAndSign(


### PR DESCRIPTION
I'm not quite sure what the issue was, but in any case, the Readable
wrapping was done only to satisfy TypeScript at some point.
