### PR TITLE
Pidetään hyvän vastauksen piirteiden liitteet transfer zipissä

### DIFF
--- a/packages/cli/__tests__/__snapshots__/createTransferZip.test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/createTransferZip.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`ee create-transfer-zip creates hi transfer zip 1`] = `
 Array [
+  "7_hvp.jpg",
   "maxmoritz.png",
   "7.2.jpg",
   "7.4.jpg",
@@ -1317,6 +1318,7 @@ exports[`ee create-transfer-zip creates hi transfer zip 2`] = `
 
 exports[`ee create-transfer-zip creates transfer zip 1`] = `
 Array [
+  "7_hvp.jpg",
   "audio-test.ogg",
   "1.ogg",
   "1.1.ogg",

--- a/packages/cli/src/commands/create-transfer-zip.ts
+++ b/packages/cli/src/commands/create-transfer-zip.ts
@@ -29,7 +29,9 @@ export default async function createTransferZip({
     const type = (examVersion.attr('exam-type')?.value() ?? 'normal') as ExamType
     const language = examVersion.attr('lang')?.value()!
     const localizedXml = localize(xml, language, type)
-    const results = await masterExam(localizedXml, () => uuid.v4(), getMediaMetadataFromLocalFile(resolveAttachment))
+    const results = await masterExam(localizedXml, () => uuid.v4(), getMediaMetadataFromLocalFile(resolveAttachment), {
+      removeCorrectAnswers: false,
+    })
     const typeSuffix = type === 'visually-impaired' ? '_vi' : type === 'hearing-impaired' ? '_hi' : ''
     const outputFilename = path.resolve(outdir, `${examName(exam)}_${language}${typeSuffix}_transfer.zip`)
 


### PR DESCRIPTION
removeCorrectAnswers arvon oletusarvo poisti hyvän vastauksen piirteet kokeesta masteroitaessa ja samalla meni liitteetkin. transfer zippiin meni kuitenkin xml jossa hvp oli mukana joten liitteetkin pitää olla mukana. 

Ylikirjoitin removeCorrectAnswersin oletusarvon.