### PR TITLE
Fix/empty annotations

### DIFF
--- a/packages/core/src/components/grading/GradingAnswer.tsx
+++ b/packages/core/src/components/grading/GradingAnswer.tsx
@@ -9,7 +9,6 @@ import {
   mergeAnnotation,
   NewImageAnnotation,
   preventDefaults,
-  selectionHasNothingToUnderline,
   showAndPositionElement,
   textAnnotationFromRange,
   toggle,
@@ -279,10 +278,10 @@ function GradingAnswerWithTranslations({
     const selection = window.getSelection()
     if (selection && answerRef.current !== null && hasTextSelectedInAnswerText()) {
       const range = selection.getRangeAt(0)
-      if (selectionHasNothingToUnderline(range)) {
+      const position = textAnnotationFromRange(answerRef.current, range)
+      if (!position) {
         return
       }
-      const position = textAnnotationFromRange(answerRef.current, range)
       const message = getOverlappingMessages(savedAnnotations[gradingRole], position.startIndex, position.length)
       newAnnotationObject = { ...position, type: 'text', message }
       showAnnotationPopup(range.getBoundingClientRect(), message)
@@ -322,10 +321,10 @@ function GradingAnswerWithTranslations({
     const selection = window.getSelection()
     if (selection && answerRef.current !== null && hasTextSelectedInAnswerText()) {
       const range = selection.getRangeAt(0)
-      if (selectionHasNothingToUnderline(range)) {
+      const position = textAnnotationFromRange(answerRef.current, range)
+      if (!position) {
         return
       }
-      const position = textAnnotationFromRange(answerRef.current, range)
       const message = getOverlappingMessages(savedAnnotations[gradingRole], position.startIndex, position.length)
       isEditAnnotationPopupVisible = true
       const inputElement = messageRef.current!

--- a/packages/rendering/src/PreviewGrading.tsx
+++ b/packages/rendering/src/PreviewGrading.tsx
@@ -55,6 +55,7 @@ function PreviewGrading() {
   }
 
   function saveAnnotations(annotations: { pregrading: Annotation[]; censoring: Annotation[] }) {
+    console.log(annotations)
     annotationsStorage.current[answerId] = annotations
     setAnnotations({ ...annotationsStorage.current[answerId] })
   }


### PR DESCRIPTION
Don't create empty annotations. This was possible by selecting line breaks between two images