### PR TITLE
Prevent DropdownAnswer from crashing when running exam in preview

### DIFF
--- a/packages/core/src/components/exam/DropdownAnswer.tsx
+++ b/packages/core/src/components/exam/DropdownAnswer.tsx
@@ -41,11 +41,12 @@ const DropdownAnswer: React.FunctionComponent<ExamComponentProps> = ({ element, 
   const menuRef = React.useRef<HTMLElement>(null)
 
   const [measuring, setMeasuring] = useState(true)
+  const [fontsLoaded, setFontsLoaded] = useState(fonts.loaded)
+
   if (runningInBrowser) {
     // Force a re-measure if element changes or fonts are loaded after this
     // component has been rendered.
-    const [, setFontsLoaded] = useState(fonts.loaded)
-    fonts.ready.then(() => setFontsLoaded(true)).catch(err => console.error(err))
+    fonts.ready.then(() => !fontsLoaded && setFontsLoaded(true)).catch(err => console.error(err))
 
     useEffect(() => setMeasuring(true), [element])
 


### PR DESCRIPTION
DropdownAnswer jäi looppaamaan renderiä, kun se avattiin, tai kun kokeen kieltä vaihdettiin suomesta ruotsiin tai päinvastoin. 

Korjauksena ajetaan `setFontsLoaded(true)` vain jos se ei vielä ole `true`, eikä joka tapauksessa. 

Epäselvää silti on, mikä tämän virheen aiheutti. Rikkova commit oli https://github.com/digabi/exam-engine/commit/e71fbcfc2c6d28315be2cdf789f2cc96a5a45f08 