### PR TITLE
Fix filtering annotations

### DIFF
--- a/packages/core/__tests__/results/AnnotationList.test.tsx
+++ b/packages/core/__tests__/results/AnnotationList.test.tsx
@@ -96,7 +96,7 @@ describe('<AnnotationList />', () => {
                   },
                   {
                     startIndex: 1,
-                    length: 1,
+                    length: 0,
                     message: ''
                   },
                   {

--- a/packages/core/__tests__/testExamRendering.tsx
+++ b/packages/core/__tests__/testExamRendering.tsx
@@ -77,7 +77,7 @@ function generateScore(question: { id: number; maxScore: number; displayNumber: 
     pregrading: {
       score: Math.min(question.maxScore, i),
       comment: `Pregading comment to question ${question.displayNumber}`,
-      annotations: [{ startIndex: 0, length: 0, message: `Pregading annotation to question ${question.displayNumber}` }]
+      annotations: [{ startIndex: 0, length: 1, message: `Pregading annotation to question ${question.displayNumber}` }]
     },
     censoring: {
       scores: [
@@ -96,7 +96,7 @@ function generateScore(question: { id: number; maxScore: number; displayNumber: 
       ],
       comment: `Censor comment to question ${question.displayNumber}`,
       annotations: [
-        { startIndex: 0, length: 0, message: `Censoring annotation to question ${question.displayNumber}` }
+        { startIndex: 0, length: 1, message: `Censoring annotation to question ${question.displayNumber}` }
       ],
       nonAnswerDetails: { shortCode: 'CEN' }
     },

--- a/packages/core/src/components/grading/GradingAnswerAnnotationList.tsx
+++ b/packages/core/src/components/grading/GradingAnswerAnnotationList.tsx
@@ -14,7 +14,7 @@ function GradingAnswerAnnotationList({
 }) {
   const getListOfAnnotations = (annotations: Annotation[], listNumberOffset = 0) =>
     annotations
-      .filter(a => a.message.length)
+      .filter(a => ('length' in a ? !!a.length : true))
       .map((annotation: Annotation, i: number) => {
         const numbering = `${String(listNumberOffset + i + 1)})`
         const message = annotation.message

--- a/packages/core/src/components/results/internal/AnnotationList.tsx
+++ b/packages/core/src/components/results/internal/AnnotationList.tsx
@@ -34,7 +34,7 @@ function ResultsAnnotationList() {
       answerElementAndScores,
       ([answer, score]) =>
         score[annotationsFrom]?.annotations
-          ?.filter(a => a.message.length)
+          ?.filter(a => ('length' in a ? !!a.length : true))
           .map((annotation: Annotation, i: number) => {
             const numbering = `${getPrefix(answers, answer) + String(listNumberOffset + i + 1)})`
             const message = annotation.message


### PR DESCRIPTION
Filter out text annotations not having length. Text annotation message can be empty (and many times actually is).