### PR TITLE
Max length only for rich text

### DIFF
--- a/packages/mastering/__tests__/fixtures/unallowed_max_length.xml
+++ b/packages/mastering/__tests__/fixtures/unallowed_max_length.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e:exam xmlns:e="http://ylioppilastutkinto.fi/exam.xsd" xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ylioppilastutkinto.fi/exam.xsd https://abitti.dev/schema/exam.xsd" exam-schema-version="0.5" date="2020-01-01">
+  <e:exam-versions>
+    <e:exam-version lang="fi-FI" exam-type="normal"/>
+  </e:exam-versions>
+  <e:exam-instruction>
+    <e:localization exam-type="normal">
+      Tekstiä tavalliseen ja näkövammaisten kokeeseen.
+    </e:localization>
+  </e:exam-instruction>
+  <e:table-of-contents />
+
+  <e:section>
+    <e:section-title>Tehtävä</e:section-title>
+    <e:question>
+        <e:question-title>
+            <e:localization lang="fi-FI">Otsikko</e:localization>
+        </e:question-title>
+
+        <e:question-instruction>
+            <e:localization lang="fi-FI" exam-type="normal">
+                Kysymys
+            </e:localization>
+        </e:question-instruction>
+        <e:localization lang="fi-FI" exam-type="normal"/>
+            <e:text-answer type="single-line" max-score="12" max-length="111">
+            <e:answer-grading-instruction>
+            <e:localization lang="fi-FI">
+              Ohje
+            </e:localization>
+        </e:answer-grading-instruction>
+    </e:text-answer>
+  </e:question>
+</e:section>
+</e:exam>

--- a/packages/mastering/__tests__/testExamMastering.ts
+++ b/packages/mastering/__tests__/testExamMastering.ts
@@ -64,6 +64,12 @@ describe('Exam mastering', () => {
         'Reference "1A" not found from available attachments: [] (fi-FI, visually-impaired)'
       )
     })
+    it('has non-rich text questions with a max length', async () => {
+      const xml = await readFixture('unallowed_max_length.xml')
+      return expect(masterExam(xml, generateUuid, getMediaMetadata)).rejects.toThrow(
+        'Only text answers with the type "rich-text" can have a max length'
+      )
+    })
   })
 
   it('validates the XML against a schema', async () => {

--- a/packages/mastering/src/mastering/index.ts
+++ b/packages/mastering/src/mastering/index.ts
@@ -286,6 +286,7 @@ async function masterExamVersion(
   addQuestionNumbers(exam)
   addAnswerNumbers(exam)
 
+  validateMaxLengthAttributes(exam)
   validateAttachments(exam, language, type)
   addAttachmentNumbers(exam)
 
@@ -626,6 +627,20 @@ function validateAttachments(exam: Exam, language: string, type: ExamType) {
       )
     }
   })
+}
+
+// Validate that only text-answers where type = rich-text have max-lenth attributes
+function validateMaxLengthAttributes(exam: Exam) {
+  const textAnswers = exam.element.find<Element>('//e:text-answer', ns)
+  const nonRichTextAnswers = textAnswers.filter(e => getAttribute('type', e) !== 'rich-text')
+  const nonRichTextAnswersWithMaxLength = nonRichTextAnswers.filter(e => getAttribute('max-length', e, false))
+
+  if (nonRichTextAnswersWithMaxLength.length) {
+    throw mkError(
+      `Only text answers with the type "rich-text" can have a max length`,
+      nonRichTextAnswersWithMaxLength[0]
+    )
+  }
 }
 
 function addAttachmentNumbers(exam: Exam) {

--- a/packages/mastering/src/mastering/index.ts
+++ b/packages/mastering/src/mastering/index.ts
@@ -162,14 +162,11 @@ function assertExamIsValid(doc: Document): Document {
     }
 
     // Validate that only text-answers where type = rich-text have max-lenth attributes
-    if (answer.name() !== "rich-text") {
+    if (answer.name() !== 'rich-text') {
       if (getAttribute('max-length', answer, false)) {
-        throw mkError(
-          `Only text answers with the type "rich-text" can have a max length`,
-          answer
-        )
+        throw mkError(`Only text answers with the type "rich-text" can have a max length`, answer)
+      }
     }
-
   }
 
   const root = doc.root()!

--- a/packages/mastering/src/mastering/index.ts
+++ b/packages/mastering/src/mastering/index.ts
@@ -632,7 +632,7 @@ function validateAttachments(exam: Exam, language: string, type: ExamType) {
 // Validate that only text-answers where type = rich-text have max-lenth attributes
 function validateMaxLengthAttributes(exam: Exam) {
   const textAnswers = exam.element.find<Element>('//e:text-answer', ns)
-  const nonRichTextAnswers = textAnswers.filter(e => getAttribute('type', e) !== 'rich-text')
+  const nonRichTextAnswers = textAnswers.filter(e => getAttribute('type', e, 'single-line') !== 'rich-text')
   const nonRichTextAnswersWithMaxLength = nonRichTextAnswers.filter(e => getAttribute('max-length', e, false))
 
   if (nonRichTextAnswersWithMaxLength.length) {

--- a/packages/mastering/src/mastering/index.ts
+++ b/packages/mastering/src/mastering/index.ts
@@ -160,6 +160,16 @@ function assertExamIsValid(doc: Document): Document {
         )
       }
     }
+
+    // Validate that only text-answers where type = rich-text have max-lenth attributes
+    if (answer.name() !== "rich-text") {
+      if (getAttribute('max-length', answer, false)) {
+        throw mkError(
+          `Only text answers with the type "rich-text" can have a max length`,
+          answer
+        )
+    }
+
   }
 
   const root = doc.root()!
@@ -286,7 +296,6 @@ async function masterExamVersion(
   addQuestionNumbers(exam)
   addAnswerNumbers(exam)
 
-  validateMaxLengthAttributes(exam)
   validateAttachments(exam, language, type)
   addAttachmentNumbers(exam)
 
@@ -627,20 +636,6 @@ function validateAttachments(exam: Exam, language: string, type: ExamType) {
       )
     }
   })
-}
-
-// Validate that only text-answers where type = rich-text have max-lenth attributes
-function validateMaxLengthAttributes(exam: Exam) {
-  const textAnswers = exam.element.find<Element>('//e:text-answer', ns)
-  const nonRichTextAnswers = textAnswers.filter(e => getAttribute('type', e, 'single-line') !== 'rich-text')
-  const nonRichTextAnswersWithMaxLength = nonRichTextAnswers.filter(e => getAttribute('max-length', e, false))
-
-  if (nonRichTextAnswersWithMaxLength.length) {
-    throw mkError(
-      `Only text answers with the type "rich-text" can have a max length`,
-      nonRichTextAnswersWithMaxLength[0]
-    )
-  }
 }
 
 function addAttachmentNumbers(exam: Exam) {

--- a/packages/mastering/src/mastering/index.ts
+++ b/packages/mastering/src/mastering/index.ts
@@ -161,8 +161,9 @@ function assertExamIsValid(doc: Document): Document {
       }
     }
 
-    // Validate that only text-answers where type = rich-text have max-lenth attributes
-    if (answer.name() !== 'rich-text') {
+    // Validate that only text-answers where type = rich-text have max-lenth attributes.
+    // default to single-line as the schema also defaults to that
+    if (getAttribute('type', answer, 'single-line') !== 'rich-text') {
       if (getAttribute('max-length', answer, false)) {
         throw mkError(`Only text answers with the type "rich-text" can have a max length`, answer)
       }


### PR DESCRIPTION
XSD 1.0 doesn't support the kind of validation needed (allow `max-length` attribute only when `type="rich-text"`) and no JS library supports XSD 1.1, so implementing the needed validation in code. Branched off of #3489, but didn't actually end up using code from that branch.