### PR TITLE
Only call addRed if it is defined

### DIFF
--- a/packages/core/src/components/exam/Question.tsx
+++ b/packages/core/src/components/exam/Question.tsx
@@ -69,7 +69,7 @@ function Question({ element, renderChildNodes }: ExamComponentProps) {
   const { addRef } = useContext(TOCContext)
 
   useEffect(() => {
-    if (ref?.current && level === 0) {
+    if (ref?.current && level === 0 && addRef) {
       addRef(ref.current)
     }
   }, [])

--- a/packages/core/src/components/exam/SectionTitle.tsx
+++ b/packages/core/src/components/exam/SectionTitle.tsx
@@ -18,7 +18,7 @@ function SectionTitle({ element, renderChildNodes }: ExamComponentProps) {
   const { addRef } = useContext(TOCContext)
 
   useEffect(() => {
-    if (ref?.current) {
+    if (ref?.current && addRef) {
       addRef(ref.current)
     }
   }, [])


### PR DESCRIPTION
addRef tarvii kutsua vain, jos kokeen vieressä on navigaatio. 
Suorituskopiossa sitä ei ole, joten addRef-funktiota ei tarvii passata Results-komponentille