### PR TITLE
Allow creating annotation over hidden annotation

### DIFF
--- a/packages/core/__tests__/annotations.test.tsx
+++ b/packages/core/__tests__/annotations.test.tsx
@@ -87,7 +87,7 @@ describe('Annotations', () => {
       length: defaultTextToAnnotate.length,
       message: 'New Value',
       selectedText: defaultTextToAnnotate,
-      startIndex: 67
+      startIndex: 0
     })
   })
 
@@ -110,7 +110,7 @@ describe('Annotations', () => {
     const exam = render(
       <Exam
         {...getExamProps()}
-        annotations={{ [defaultAnnotationAnchor]: [createAnnotation(1, 1, 1)] }}
+        annotations={{ [defaultAnnotationAnchor]: [createAnnotation(1, 5, 12, 'moraali että')] }}
         onClickAnnotation={clickAnnotationMock}
         onSaveAnnotation={() => {}}
       />
@@ -123,26 +123,26 @@ describe('Annotations', () => {
       annotationId: 1,
       displayNumber: '',
       hidden: false,
-      length: 1,
+      length: 12,
       message: '',
-      selectedText: '',
-      startIndex: 1
+      selectedText: 'moraali että',
+      startIndex: 5
     })
   })
 
   it('annotations are added to dom when provided', () => {
     const annotationProps: AnnotationProps = {
       annotations: {
-        [defaultAnnotationAnchor]: [createAnnotation(1, 1, 3), createAnnotation(3, 4, 5)]
+        [defaultAnnotationAnchor]: [createAnnotation(1, 5, 7, 'moraali'), createAnnotation(3, 18, 5, 'tavat')]
       },
       onClickAnnotation: () => {},
       onSaveAnnotation: () => {}
     }
     const exam = render(<Exam {...getExamProps()} {...annotationProps} />)
     expect(exam.container.querySelector('[data-annotation-id="1"]')).toBeInTheDocument()
-    expect(exam.container.querySelector('[data-annotation-id="1"]')?.textContent).toBe('ekä')
+    expect(exam.container.querySelector('[data-annotation-id="1"]')?.textContent).toBe('moraali')
     expect(exam.container.querySelector('[data-annotation-id="3"]')).toBeInTheDocument()
-    expect(exam.container.querySelector('[data-annotation-id="3"]')?.textContent).toBe(' mora')
+    expect(exam.container.querySelector('[data-annotation-id="3"]')?.textContent).toBe('tavat')
   })
 
   it('hidden annotation works correctly', () => {
@@ -153,11 +153,11 @@ describe('Annotations', () => {
             annotationId: 1,
             annotationAnchor: defaultAnnotationAnchor,
             hidden: true,
-            startIndex: 0,
-            length: 10,
+            startIndex: 24,
+            length: 8,
             message: '',
             displayNumber: '',
-            selectedText: ''
+            selectedText: 'pyrkivät'
           }
         ]
       },
@@ -192,7 +192,7 @@ describe('Annotations', () => {
     expect(gi.getByTestId('annotation-popup')).toBeVisible()
   })
 
-  function createAnnotation(id: number, startIndex: number, length: number): ExamAnnotation {
+  function createAnnotation(id: number, startIndex: number, length: number, selectedText: string): ExamAnnotation {
     return {
       annotationId: id,
       annotationAnchor: defaultAnnotationAnchor,
@@ -201,25 +201,25 @@ describe('Annotations', () => {
       length,
       message: '',
       displayNumber: '',
-      selectedText: ''
+      selectedText
     }
   }
 
   async function annotateText(exam: RenderResult, text: string) {
-    mockWindowSelection(text, text.length)
     const textElement = exam.getByText(text)
+    mockWindowSelection(text, text.length, textElement)
     await userEvent.click(textElement)
   }
 
-  function mockWindowSelection(text = 'mocked selection text', length = 5) {
+  function mockWindowSelection(text = 'mocked selection text', length = 5, element: Element) {
     ;(window.getSelection as jest.Mock).mockImplementation(() => ({
       toString: () => text,
       rangeCount: 1,
       getRangeAt: jest.fn().mockReturnValue({
         startOffset: 0,
         endOffset: length,
-        startContainer: {},
-        endContainer: {},
+        startContainer: element,
+        endContainer: element,
         cloneContents: jest.fn().mockReturnValue({ children: [], childNodes: [] })
       })
     }))

--- a/packages/core/src/components/grading/editAnnotations.ts
+++ b/packages/core/src/components/grading/editAnnotations.ts
@@ -14,6 +14,7 @@ export function textAnnotationFromRange(answerTextNode: Element, range: Range) {
   if (length <= 0) {
     return undefined
   }
+
   return {
     startIndex: charactersBefore,
     length

--- a/packages/core/src/components/grading/examAnnotationUtils.ts
+++ b/packages/core/src/components/grading/examAnnotationUtils.ts
@@ -1,5 +1,5 @@
-import { textAnnotationFromRange } from './editAnnotations'
 import React from 'react'
+import { textAnnotationFromRange } from './editAnnotations'
 
 export function onMouseDownForAnnotation(e: React.MouseEvent, mouseUpCallback: (e: any) => void) {
   function onMouseUpAfterAnswerMouseDown(e: MouseEvent) {
@@ -43,11 +43,14 @@ export function hasTextSelectedInAnswerText(): boolean {
     const endContainer = sel.getRangeAt(0).endContainer
     const startParent = startContainer.parentElement
     const endParent = endContainer.parentElement
-    const markTagExistsInSelection = Array.from(sel.getRangeAt(0).cloneContents().children).some(
-      child => child.tagName === 'MARK' && child.getAttribute('data-annotation-id')
+    const visibleMarkTagExistsInSelection = Array.from(sel.getRangeAt(0).cloneContents().children).some(
+      child => child.tagName === 'MARK' && child.getAttribute('data-hidden') === 'false'
     )
     return (
-      sel.rangeCount > 0 && startParent === endParent && startParent?.tagName !== 'MARK' && !markTagExistsInSelection
+      sel.rangeCount > 0 &&
+      startParent === endParent &&
+      startParent?.tagName !== 'MARK' &&
+      !visibleMarkTagExistsInSelection
     )
   }
 

--- a/packages/core/src/components/shared/AnnotatableText.tsx
+++ b/packages/core/src/components/shared/AnnotatableText.tsx
@@ -1,9 +1,9 @@
+import { partition } from 'lodash-es'
 import React, { useEffect, useRef } from 'react'
-import { AnnotationContextType } from '../context/AnnotationProvider'
 import { getElementPath, queryAncestors } from '../../dom-utils'
-import { onMouseDownForAnnotation } from '../grading/examAnnotationUtils'
 import { ExamAnnotation, NewExamAnnotation } from '../../types/Score'
-import { partition } from 'lodash'
+import { AnnotationContextType } from '../context/AnnotationProvider'
+import { onMouseDownForAnnotation } from '../grading/examAnnotationUtils'
 
 const isExamAnnotation = (annotation: NewExamAnnotation | ExamAnnotation): annotation is ExamAnnotation =>
   'annotationId' in annotation

--- a/packages/core/src/components/shared/AnnotatableText.tsx
+++ b/packages/core/src/components/shared/AnnotatableText.tsx
@@ -48,14 +48,21 @@ export const AnnotatableText = ({
       return [text]
     }
 
+    function getMarkedText(annotation: NewExamAnnotation) {
+      return text.substring(annotation.startIndex, annotation.startIndex + annotation.length)
+    }
+
     const nodes: React.ReactNode[] = []
     let lastIndex = 0
     annotations.sort((a, b) => a.startIndex - b.startIndex)
 
-    for (const annotation of annotations) {
-      if (annotation.startIndex < 0 || annotation.length <= 0) {
-        return [text]
-      }
+    const validAnnotations = annotations.filter(
+      annotation =>
+        annotation.startIndex >= 0 && annotation.length > 0 && annotation.selectedText === getMarkedText(annotation)
+    )
+
+    for (const annotation of validAnnotations) {
+      const markedText = getMarkedText(annotation)
 
       // Add unmarked text before this mark
       if (annotation.startIndex > lastIndex) {
@@ -63,22 +70,18 @@ export const AnnotatableText = ({
       }
 
       // Add marked text
-      const markedText = text.substring(annotation.startIndex, annotation.startIndex + annotation.length)
-
+      const key = isExamAnnotation(annotation) ? annotation.annotationId : annotation.startIndex
       nodes.push(
         annotation.hidden ? (
-          <React.Fragment key={annotation.startIndex}>
-            <mark
-              key={annotation.startIndex}
-              className="e-annotation"
-              data-annotation-id={isExamAnnotation(annotation) ? annotation.annotationId : ''}
-              data-hidden="true"
-            />
-            {markedText}
-          </React.Fragment>
+          <mark
+            key={key}
+            className="e-annotation"
+            data-annotation-id={isExamAnnotation(annotation) ? annotation.annotationId : ''}
+            data-hidden="true"
+          />
         ) : (
           <Mark
-            key={annotation.startIndex}
+            key={key}
             annotation={annotation}
             markedText={markedText}
             onClickAnnotation={onClickAnnotation!}
@@ -87,7 +90,12 @@ export const AnnotatableText = ({
         )
       )
 
-      lastIndex = annotation.startIndex + annotation.length
+      // if annotation is hidden and it starts inside another annotation, we must not increment lastIndex (actually it would be decremented)
+      const hiddenAnnotationInsideCurrentAnnotation = annotation.startIndex < lastIndex && annotation.hidden
+
+      if (!hiddenAnnotationInsideCurrentAnnotation) {
+        lastIndex = annotation.startIndex + (annotation.hidden ? 0 : annotation.length)
+      }
     }
 
     // Add remaining unmarked text

--- a/packages/core/src/components/shared/AnnotatableText.tsx
+++ b/packages/core/src/components/shared/AnnotatableText.tsx
@@ -3,6 +3,7 @@ import { AnnotationContextType } from '../context/AnnotationProvider'
 import { getElementPath, queryAncestors } from '../../dom-utils'
 import { onMouseDownForAnnotation } from '../grading/examAnnotationUtils'
 import { ExamAnnotation, NewExamAnnotation } from '../../types/Score'
+import { partition } from 'lodash'
 
 const isExamAnnotation = (annotation: NewExamAnnotation | ExamAnnotation): annotation is ExamAnnotation =>
   'annotationId' in annotation
@@ -56,10 +57,22 @@ export const AnnotatableText = ({
     let lastIndex = 0
     annotations.sort((a, b) => a.startIndex - b.startIndex)
 
-    const validAnnotations = annotations.filter(
+    const [validAnnotations, invalidAnnotations] = partition(
+      annotations,
       annotation =>
         annotation.startIndex >= 0 && annotation.length > 0 && annotation.selectedText === getMarkedText(annotation)
     )
+
+    if (invalidAnnotations.length > 0) {
+      console.error(
+        'Invalid annotations:',
+        invalidAnnotations,
+        invalidAnnotations.map(
+          a =>
+            `selectedText (${a.selectedText}) does not match text picked by startIndex and length (${getMarkedText(a)})`
+        )
+      )
+    }
 
     for (const annotation of validAnnotations) {
       const markedText = getMarkedText(annotation)


### PR DESCRIPTION
Annotaation saa tehdä mark-tägin yli, jos mark-tägillä on data-hidden="true"

Tämä vaati myös muutoksia siihen, miten annotaatioida rendataan ja indeksiä siirrellään. 