### PR TITLE
Move useContext(AnnotationContext) from renderTextNode to Annotatable…

### DIFF
--- a/packages/core/src/components/exam/DropdownAnswer.less
+++ b/packages/core/src/components/exam/DropdownAnswer.less
@@ -123,7 +123,7 @@
     }
 
     span.e-dropdown-answer__menu-item {
-      &.e-bg-color-link {
+      &.e-bg-color-link:has(.e-annotatable) {
         background-color: white;
         color: #222;
       }

--- a/packages/core/src/components/shared/AnnotatableText.tsx
+++ b/packages/core/src/components/shared/AnnotatableText.tsx
@@ -1,21 +1,27 @@
 import { partition } from 'lodash-es'
-import React, { useEffect, useRef } from 'react'
+import React, { useContext, useEffect, useRef } from 'react'
 import { getElementPath, queryAncestors } from '../../dom-utils'
 import { ExamAnnotation, NewExamAnnotation } from '../../types/Score'
-import { AnnotationContextType } from '../context/AnnotationProvider'
+import { AnnotationContext } from '../context/AnnotationProvider'
 import { onMouseDownForAnnotation } from '../grading/examAnnotationUtils'
+import { IsInSidebarContext } from '../context/IsInSidebarContext'
 
 const isExamAnnotation = (annotation: NewExamAnnotation | ExamAnnotation): annotation is ExamAnnotation =>
   'annotationId' in annotation
 
-export const AnnotatableText = ({
-  node,
-  annotationContextData
-}: {
-  node: Node
-  annotationContextData: AnnotationContextType
-}) => {
+export const AnnotatableText = ({ node }: { node: Node }) => {
+  const annotationContextData = useContext(AnnotationContext)
+  const { isInSidebar } = useContext(IsInSidebarContext)
   const { annotations, onClickAnnotation, setNewAnnotation, setNewAnnotationRef, newAnnotation } = annotationContextData
+
+  const canNotBeAnnotated =
+    annotationContextData?.annotations === undefined ||
+    node.textContent?.trim().length === 0 ||
+    isInSidebar !== undefined
+
+  if (canNotBeAnnotated) {
+    return node.textContent!
+  }
 
   const path = getElementPath(node as Element)
   const newAnnotationForThisNode = newAnnotation?.annotationAnchor === path ? newAnnotation : null

--- a/packages/core/src/createRenderChildNodes.tsx
+++ b/packages/core/src/createRenderChildNodes.tsx
@@ -1,6 +1,4 @@
-import React, { useContext } from 'react'
-import { AnnotationContext } from './components/context/AnnotationProvider'
-import { IsInSidebarContext } from './components/context/IsInSidebarContext'
+import React from 'react'
 import { getElementPath, mapChildNodes } from './dom-utils'
 import { AnnotatableText } from './components/shared/AnnotatableText'
 
@@ -75,20 +73,7 @@ export function createRenderChildNodes(
 }
 
 function renderTextNode(node: Node) {
-  const annotationContextData = useContext(AnnotationContext)
-  const { isInSidebar } = useContext(IsInSidebarContext)
-
-  if (
-    annotationContextData?.annotations === undefined ||
-    node.textContent?.trim().length === 0 ||
-    isInSidebar !== undefined
-  ) {
-    return node.textContent!
-  }
-
-  return (
-    <AnnotatableText node={node} annotationContextData={annotationContextData} key={getElementPath(node as Element)} />
-  )
+  return <AnnotatableText node={node} key={getElementPath(node as Element)} />
 }
 
 function htmlAttributes2props<T extends HTMLElement>(element: T, index: number): React.HTMLProps<T> {


### PR DESCRIPTION
…Text.tsx;

This was causing an error to be printed into console when dropdown option was first selected in the page. After the change, there is no error. The original culprit is the conditional rendering for selectedItem in dropdownanswer. Choice answers do not contain this condition, so there was no error there.