### PR TITLE
First trim line breaks, then multiple spaces

### DIFF
--- a/packages/core/__tests__/annotations.test.tsx
+++ b/packages/core/__tests__/annotations.test.tsx
@@ -101,7 +101,8 @@ describe('Annotations', () => {
       target: { innerText: 'New Value', innerHTML: 'New Value' }
     })
     await userEvent.click(exam.getByText('Vastaa'))
-    await annotateText(exam, 'Esitä jokin toinen käsitys filosofiasta ja vertaa sitä')
+    // text picked by getMarkedText includes leading/trailing whitespace, so they must be here too
+    await annotateText(exam, ' Esitä jokin toinen käsitys filosofiasta ja vertaa sitä ')
     expect(exam.getByTestId('edit-comment').textContent).toHaveLength(0)
   })
 
@@ -206,7 +207,7 @@ describe('Annotations', () => {
   }
 
   async function annotateText(exam: RenderResult, text: string) {
-    const textElement = exam.getByText(text)
+    const textElement = exam.getByText(text.trim()) // text is not found unless trimmed
     mockWindowSelection(text, text.length, textElement)
     await userEvent.click(textElement)
   }

--- a/packages/core/src/components/shared/AnnotatableText.tsx
+++ b/packages/core/src/components/shared/AnnotatableText.tsx
@@ -44,7 +44,7 @@ export const AnnotatableText = ({ node }: { node: Node }) => {
     onMouseDownForAnnotation(e, mouseUpCallback)
   }
 
-  const textWithoutLineBreaksAndExtraSpaces = node.textContent!.replace(/\n|\s+/g, ' ')
+  const textWithoutLineBreaksAndExtraSpaces = node.textContent!.replace(/\n/g, ' ').replace(/\s+/g, ' ')
 
   return (
     <span onMouseDown={onMouseDown} className="e-annotatable" key={path}>


### PR DESCRIPTION
Tällä vasta poistuu se console.error, joka tuli testissä. 
Nyt xml:stä trimmataan ensin kaikki rivinvaihdot välilyönneiksi, ja vasta sitten kaikki monivälilyönnit yksittäisiksi välilyönneiksi. 