### PR TITLE
Prevent duplicate annotations

### DIFF
--- a/packages/core/src/dom-utils.ts
+++ b/packages/core/src/dom-utils.ts
@@ -178,9 +178,10 @@ export function getElementPath(element: Element): string {
   while (currentElement.parentElement) {
     currentElement = currentElement.parentElement
     const displayNumber = currentElement.getAttribute('display-number')
-    const index =
-      Number(displayNumber) ||
-      Array.from(currentElement.parentElement?.children || [currentElement]).indexOf(currentElement)
+    const isNumber = Number(displayNumber)
+    const index = isNumber
+      ? displayNumber
+      : Array.from(currentElement.parentElement?.children || [currentElement]).indexOf(currentElement)
     const elementId = currentElement.getAttribute('id')
     path = `${elementId || currentElement.nodeName}:${index} > ${path}`
   }


### PR DESCRIPTION
Number(displayNumber) gave same number for 7.1 and 7.10 and showed annotations in both places.

There are displayNumbers with alphabets like 7.A. Old implementation did not handle them properly. Keep old implementation for them to keep old annotations working.