### PR TITLE
Disable new formula button if formula popup is already open

### DIFF
--- a/packages/core/__tests__/editor/Formula.test.tsx
+++ b/packages/core/__tests__/editor/Formula.test.tsx
@@ -32,8 +32,9 @@ describe('Editor - Formula', () => {
   it('Change in content causes formula to be returned as expected', async () => {
     cleanup = mockCreateRange()
     const inputData =
-      '<p>bar</p><p><e:formula data-editor-id="e-formula" mode="inline">foo</e:formula><e:formula data-editor-id="e-formula">bar</e:formula></p>'
-    const expectedOutput = '<p>foo</p><p><e:formula mode="inline">foo</e:formula><e:formula>bar</e:formula></p>'
+      '<p>bar</p><p><e:formula data-editor-id="e-formula" mode="inline">foo</e:formula><e:formula data-editor-id="e-formula" assistive-title="foobar">bar</e:formula></p>'
+    const expectedOutput =
+      '<p>foo</p><p><e:formula mode="inline">foo</e:formula><e:formula assistive-title="foobar">bar</e:formula></p>'
     const result = renderGradingInstruction(inputData, onContentChangeMock)
     await act(async () => {
       insertText(await result.findByText('bar'), 'foo')

--- a/packages/core/__tests__/editor/Formula.test.tsx
+++ b/packages/core/__tests__/editor/Formula.test.tsx
@@ -41,4 +41,16 @@ describe('Editor - Formula', () => {
     expect(onContentChangeMock).toHaveBeenCalledTimes(1)
     expect(onContentChangeMock).toHaveBeenCalledWith(expectedOutput, '')
   })
+
+  it('Empty formula is removed when sending changed content', async () => {
+    cleanup = mockCreateRange()
+    const inputData = '<p>bar</p><p><e:formula data-editor-id="e-formula"></e:formula></p>'
+    const expectedOutput = '<p>foo</p><p></p>'
+    const result = renderGradingInstruction(inputData, onContentChangeMock)
+    await act(async () => {
+      insertText(await result.findByText('bar'), 'foo')
+    })
+    expect(onContentChangeMock).toHaveBeenCalledTimes(1)
+    expect(onContentChangeMock).toHaveBeenCalledWith(expectedOutput, '')
+  })
 })

--- a/packages/core/src/components/grading-instructions/EditableGradingInstruction.tsx
+++ b/packages/core/src/components/grading-instructions/EditableGradingInstruction.tsx
@@ -16,15 +16,19 @@ import { ImageUploadButton } from './editor/ImageUploadButton'
 import { imageInputSchema, imageOutputSchema } from './editor/schemas/image-schema'
 import { CommonExamContext } from '../context/CommonExamContext'
 
-function Menu(props: { setFormulaState: (values: FormulaEditorState) => void }) {
+function Menu(props: {
+  formulaState: FormulaEditorState | null
+  setFormulaState: (values: FormulaEditorState) => void
+}) {
   const { onSaveImage } = useContext(GradingInstructionContext)
+
   return (
     <>
       <FormatButton markName="strong" displayName="Bold" />
       <FormatButton markName="em" displayName="Italic" />
       {onSaveImage && <ImageUploadButton saveImage={onSaveImage} />}
       <TableMenu />
-      <FormulaButton setFormulaState={props.setFormulaState} />
+      <FormulaButton disabled={!!props.formulaState} setFormulaState={props.setFormulaState} />
       <NbspButton />
     </>
   )
@@ -74,7 +78,7 @@ function EditableGradingInstruction({ element }: { element: Element }) {
         }
       }}
     >
-      <Menu setFormulaState={setFormulaState} />
+      <Menu formulaState={formulaState} setFormulaState={setFormulaState} />
       <div ref={setMount} />
 
       {formulaState && (

--- a/packages/core/src/components/grading-instructions/editor/Formula.tsx
+++ b/packages/core/src/components/grading-instructions/editor/Formula.tsx
@@ -13,7 +13,8 @@ export const formulaSchema: NodeSpec = {
     atom: true,
     attrs: {
       latex: {},
-      mode: { default: '' }
+      mode: { default: '' },
+      assistiveTitle: { default: '' }
     },
     parseDOM: [
       {
@@ -21,7 +22,8 @@ export const formulaSchema: NodeSpec = {
         getAttrs(dom: HTMLElement) {
           return {
             latex: dom.textContent,
-            mode: dom.getAttribute('mode')
+            mode: dom.getAttribute('mode'),
+            assistiveTitle: dom.getAttribute('assistive-title')
           }
         }
       }
@@ -44,8 +46,16 @@ export const formulaOutputSchema: NodeSpec = {
       if (!node.attrs.latex) {
         return ''
       }
+      const formulaElement = document.createElement('e:formula')
+      if (node.attrs.mode) {
+        formulaElement.setAttribute('mode', node.attrs.mode as string)
+      }
+      if (node.attrs.assistiveTitle) {
+        formulaElement.setAttribute('assistive-title', node.attrs.assistiveTitle as string)
+      }
+      formulaElement.textContent = node.attrs.latex as string
       const container = document.createElement('span')
-      container.innerHTML = `<e:formula ${node.attrs.mode ? `mode="${node.attrs.mode}"` : ''}>${node.attrs.latex}</e:formula>`
+      container.appendChild(formulaElement)
       return container.firstElementChild!
     }
   }

--- a/packages/core/src/components/grading-instructions/editor/Formula.tsx
+++ b/packages/core/src/components/grading-instructions/editor/Formula.tsx
@@ -48,7 +48,7 @@ export const formulaOutputSchema: NodeSpec = {
   }
 }
 
-export function FormulaButton(props: { setFormulaState: (values: FormulaEditorState) => void }) {
+export function FormulaButton(props: { disabled: boolean; setFormulaState: (values: FormulaEditorState) => void }) {
   const onClick = useEditorEventCallback(view => {
     const transaction: Transaction = view.state.tr
     const formula = view.state.schema.nodes.formula.create({ latex: '' }, Fragment.empty)
@@ -64,7 +64,7 @@ export function FormulaButton(props: { setFormulaState: (values: FormulaEditorSt
   })
 
   return (
-    <button onClick={onClick} data-testid="add-formula">
+    <button onClick={onClick} data-testid="add-formula" disabled={props.disabled}>
       Lisää kaava
     </button>
   )

--- a/packages/core/src/components/grading-instructions/editor/Formula.tsx
+++ b/packages/core/src/components/grading-instructions/editor/Formula.tsx
@@ -41,6 +41,9 @@ export const formulaOutputSchema: NodeSpec = {
   formula: {
     ...(formulaSchema.formula as AttributeSpec),
     toDOM(node: Node) {
+      if (!node.attrs.latex) {
+        return ''
+      }
       const container = document.createElement('span')
       container.innerHTML = `<e:formula ${node.attrs.mode ? `mode="${node.attrs.mode}"` : ''}>${node.attrs.latex}</e:formula>`
       return container.firstElementChild!

--- a/packages/rendering/__tests__/testEditableGradingInstruction.ts
+++ b/packages/rendering/__tests__/testEditableGradingInstruction.ts
@@ -27,6 +27,14 @@ describe('testEditableGradingInstruction.ts — Grading instruction editing', ()
       )
     })
 
+    it('New equation cannot be added if formula popup is already open', async () => {
+      await openGradingInstructionsPage()
+      await focusOnEditor()
+      expect(await getDisabledStatus(page, '.e-answer-grading-instruction [data-testid="add-formula"]')).toBeFalsy()
+      await addFormula()
+      expect(await getDisabledStatus(page, '.e-answer-grading-instruction [data-testid="add-formula"]')).toBeTruthy()
+    })
+
     it('Equation can be deleted', async () => {
       await openGradingInstructionsPage()
       await addEquation('\\sqrt{1}')
@@ -71,6 +79,15 @@ describe('testEditableGradingInstruction.ts — Grading instruction editing', ()
       expect(await page.waitForSelector(`[data-testid="e-popup-save"]:disabled`)).toBeTruthy()
       expect(await getInnerHtml('.e-popup-error')).toBe('Ainoastaan yksi kaava sallittu')
     })
+
+    async function getDisabledStatus(page: Page, selector: string): Promise<boolean> {
+      return page.$eval(selector, e => {
+        if (e instanceof HTMLButtonElement) {
+          return e.disabled
+        }
+        throw new Error('Not a button')
+      })
+    }
 
     async function replaceLatex(latex: string) {
       await clearInput('.math-editor-latex-field')


### PR DESCRIPTION
- Tuetaan e:formulan assistive-titlejä
Pari korjausta siihen että e:formula käyttää placeholderia kaavan luonnin ajan. Sitä tarvitaan jotta osataan kohdistaa popup oikeaan kohtaan sivulla.
- uutta kaavaa ei voi luoda jos formula popup on auki 
- ei lähetetä tyhjiä e:formula tägejä