### PR TITLE
Warn if some images are not loaded; count also completed images, not only loaded

### DIFF
--- a/packages/core/src/components/grading/GradingAnswer.less
+++ b/packages/core/src/components/grading/GradingAnswer.less
@@ -71,14 +71,25 @@
   font-size: 16px;
   overflow: hidden;
   display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
   animation: fade-in 0.5s ease-in-out both;
   animation-delay: 0.5s;
 
   span {
     border-radius: 4px;
-    border: 1px solid orange;
     padding: 0.25rem 0.75rem;
-    background: #fff8eb;
+
+    &.loading {
+      border: 1px solid orange;
+      background: #fff8eb;
+    }
+
+    &.failed {
+      border: 1px solid rgb(189, 0, 0);
+      background: #ffebeb;
+    }
   }
 
   @keyframes fade-in {

--- a/packages/core/src/components/grading/GradingAnswer.tsx
+++ b/packages/core/src/components/grading/GradingAnswer.tsx
@@ -80,22 +80,42 @@ function GradingAnswerWithTranslations({
 
   const [loadedCount, setLoadedCount] = useState(0)
   const [totalImages, setTotalImages] = useState(0)
+  const [failedImages, setFailedImages] = useState(0)
 
   useEffect(() => {
-    const nonEmptyImages = document.querySelectorAll('img[src]')
-    setLoadedCount(0)
-    setTotalImages(nonEmptyImages.length)
-    function checkAllImagesLoaded() {
+    const nonEmptyImages = document.querySelectorAll('.e-grading-answer img[src]')
+    function handleImageLoaded() {
       setLoadedCount(prevCount => prevCount + 1)
     }
 
-    nonEmptyImages.forEach(img => {
-      img.addEventListener('load', checkAllImagesLoaded)
+    function handleImageError(img: HTMLImageElement) {
+      console.error('Image failed to load:', img.src)
+      setFailedImages(prevCount => prevCount + 1)
+      img.alt = 'Image failed to load'
+      img.style.border = '1px solid red'
+    }
+
+    setTotalImages(nonEmptyImages?.length || 0)
+    setLoadedCount(0)
+    setFailedImages(0)
+
+    nonEmptyImages?.forEach(img => {
+      if (img instanceof HTMLImageElement) {
+        if (img.complete) {
+          handleImageLoaded()
+        } else {
+          img.addEventListener('load', handleImageLoaded)
+          img.addEventListener('error', () => handleImageError(img))
+        }
+      }
     })
 
     return () => {
-      nonEmptyImages.forEach(img => {
-        img.removeEventListener('load', checkAllImagesLoaded)
+      nonEmptyImages?.forEach(img => {
+        if (img instanceof HTMLImageElement) {
+          img.removeEventListener('load', handleImageLoaded)
+          img.removeEventListener('error', () => handleImageError(img))
+        }
       })
     }
   }, [value])
@@ -122,13 +142,20 @@ function GradingAnswerWithTranslations({
   })
 
   const { t } = useExamTranslation()
+
+  const notAllImagesLoaded = totalImages !== 0 && loadedCount !== totalImages
+  const someImagesFailedToLoad = failedImages > 0
+
   return (
     <div onClick={e => onAnnotationOrListClick(e)} className="e-grading-answer-wrapper">
-      {totalImages !== 0 && loadedCount !== totalImages && (
+      {(notAllImagesLoaded || someImagesFailedToLoad) && (
         <div className="loading-images">
-          <span>
-            {t('grading.loading-images')} ({loadedCount}/{totalImages})
-          </span>
+          {notAllImagesLoaded && (
+            <span className="loading">
+              {t('grading.loading-images')} ({loadedCount + failedImages}/{totalImages})
+            </span>
+          )}
+          {someImagesFailedToLoad && <span className="failed">{t('grading.some-images-failed')}</span>}
         </div>
       )}
       <div

--- a/packages/core/src/components/grading/GradingAnswer.tsx
+++ b/packages/core/src/components/grading/GradingAnswer.tsx
@@ -1,5 +1,15 @@
 import React, { FormEvent, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { I18nextProvider } from 'react-i18next'
 import { Annotation, TextAnnotation } from '../..'
+import { changeLanguage, initI18n, useExamTranslation } from '../../i18n'
+import {
+  renderAnnotations,
+  renderImageAnnotationByImage,
+  updateImageAnnotationMarkSize,
+  wrapAllImages
+} from '../../renderAnnotations'
+import { useCached } from '../../useCached'
+import { AnswerCharacterCounter } from './AnswerCharacterCounter'
 import {
   annotationFromMousePosition,
   getOverlappingMessages,
@@ -13,18 +23,8 @@ import {
   textAnnotationFromRange,
   toggle
 } from './editAnnotations'
-import {
-  renderAnnotations,
-  renderImageAnnotationByImage,
-  updateImageAnnotationMarkSize,
-  wrapAllImages
-} from '../../renderAnnotations'
 import GradingAnswerAnnotationList from './GradingAnswerAnnotationList'
-import { changeLanguage, initI18n, useExamTranslation } from '../../i18n'
 import { updateLargeImageWarnings } from './largeImageDetector'
-import { I18nextProvider } from 'react-i18next'
-import { useCached } from '../../useCached'
-import { AnswerCharacterCounter } from './AnswerCharacterCounter'
 type Annotations = { pregrading: Annotation[]; censoring: Annotation[] }
 
 type GradingRole = 'pregrading' | 'censoring'
@@ -143,18 +143,16 @@ function GradingAnswerWithTranslations({
 
   const { t } = useExamTranslation()
 
-  const notAllImagesLoaded = totalImages !== 0 && loadedCount !== totalImages
+  const allImagesLoaded = totalImages > 0 && loadedCount === totalImages
   const someImagesFailedToLoad = failedImages > 0
 
   return (
     <div onClick={e => onAnnotationOrListClick(e)} className="e-grading-answer-wrapper">
-      {(notAllImagesLoaded || someImagesFailedToLoad) && (
+      {!allImagesLoaded && (
         <div className="loading-images">
-          {notAllImagesLoaded && (
-            <span className="loading">
-              {t('grading.loading-images')} ({loadedCount + failedImages}/{totalImages})
-            </span>
-          )}
+          <span className="loading">
+            {t('grading.loading-images')} ({loadedCount}/{totalImages})
+          </span>
           {someImagesFailedToLoad && <span className="failed">{t('grading.some-images-failed')}</span>}
         </div>
       )}

--- a/packages/core/src/i18n/fi-FI.ts
+++ b/packages/core/src/i18n/fi-FI.ts
@@ -48,7 +48,8 @@ export const fi_FI = {
     'round.3': '3.s',
     annotate: 'Merkitse',
     'non-answer-not-graded': 'Jätetty arvostelematta',
-    'loading-images': 'Odota, kuvia ladataan...'
+    'loading-images': 'Odota, kuvia ladataan...',
+    'some-images-failed': 'Joidenkin kuvien lataaminen epäonnistui. Päivitä sivu.'
   },
   references: {
     heading: 'Lähteet',

--- a/packages/core/src/i18n/sv-FI.ts
+++ b/packages/core/src/i18n/sv-FI.ts
@@ -38,7 +38,7 @@ export const sv_FI: Translations = {
     annotate: 'Markera',
     'non-answer-not-graded': 'Lämnats utan bedömning',
     'loading-images': 'Vänta, bilder laddas...',
-    'some-images-failed': 'TODO.'
+    'some-images-failed': 'Laddning av vissa bilder misslyckades. Var god uppdatera sidan.'
   },
   references: {
     heading: 'Källor',

--- a/packages/core/src/i18n/sv-FI.ts
+++ b/packages/core/src/i18n/sv-FI.ts
@@ -37,7 +37,8 @@ export const sv_FI: Translations = {
     'round.3': '3.c',
     annotate: 'Markera',
     'non-answer-not-graded': 'Lämnats utan bedömning',
-    'loading-images': 'Vänta, bilder laddas...'
+    'loading-images': 'Vänta, bilder laddas...',
+    'some-images-failed': 'TODO.'
   },
   references: {
     heading: 'Källor',


### PR DESCRIPTION
- Lasketaan kokonaiskuvamäärä vain vastauksesta, ei koko sivulta
- Lasketaan kuva ladatuksi myös, jos `img.complete`
- Lisätty `img.onError`-handler. Jos tulee virheitä, niin näytetään kehotus ladata sivu uudestaan