### PR TITLE
Add support for resolved annotations

### DIFF
--- a/packages/core/__tests__/playwright/Annotations.test.tsx
+++ b/packages/core/__tests__/playwright/Annotations.test.tsx
@@ -146,6 +146,7 @@ test.describe('Annotations', () => {
           annotationId: 1,
           hidden: false,
           length: 8,
+          resolved: undefined,
           selectedText: 'pienempi',
           startIndex: 27,
           markNumber: 1

--- a/packages/core/src/components/context/AnnotationProvider.tsx
+++ b/packages/core/src/components/context/AnnotationProvider.tsx
@@ -61,7 +61,8 @@ export const AnnotationProvider = ({
               ...p,
               annotationId: a.annotationId,
               markNumber: isLastChild ? a.markNumber : undefined,
-              hidden: a.hidden
+              hidden: a.hidden,
+              resolved: a?.resolved
             }
           })
         ) || [],

--- a/packages/core/src/components/shared/AnnotationMark.tsx
+++ b/packages/core/src/components/shared/AnnotationMark.tsx
@@ -25,7 +25,7 @@ export const AnnotationMark = ({
   return (
     <mark
       ref={markRef}
-      className="e-annotation"
+      className={`e-annotation ${annotation.resolved ? 'resolved' : ''}`}
       data-annotation-id={isExistingAnnotation(annotation) ? annotation.annotationId : ''}
       data-hidden="false"
       data-annotation-path={annotation.annotationAnchor}

--- a/packages/core/src/css/annotations.less
+++ b/packages/core/src/css/annotations.less
@@ -41,6 +41,11 @@
     background-color: @annotation-background-selected;
   }
 
+  &.resolved {
+    background-color: #1112;
+    outline-color: #1112;
+  }
+
   &[data-hidden='true'] {
     background: none;
     outline: none;

--- a/packages/core/src/types/Score.ts
+++ b/packages/core/src/types/Score.ts
@@ -57,6 +57,7 @@ export interface NewExamAnnotation {
   annotationParts: AnnotationPart[]
   hidden: boolean
   markNumber?: number
+  resolved?: boolean
 }
 
 export interface ExamAnnotation extends NewExamAnnotation {
@@ -71,6 +72,7 @@ export interface AnnotationPart {
   length: number
   markNumber?: number
   hidden?: boolean
+  resolved?: boolean
 }
 
 export interface RenderableAnnotation extends AnnotationPart {


### PR DESCRIPTION
Kun exam-maker passaa annotation.resolved EE:lle, niin EE osaa näyttää sen eri tavalla (harmaana) 