### PR TITLE
fix: replace reference to non-existent svg-file with inline svg

### DIFF
--- a/packages/core/src/components/exam/UndoView.tsx
+++ b/packages/core/src/components/exam/UndoView.tsx
@@ -249,15 +249,22 @@ const CloseButton = ({ close }: { close: () => void }) => {
   const { t } = useExamTranslation()
   return (
     <div>
-      <img
-        src="img/closeButton.svg"
+      <svg
         id="closeUndoDialogButton"
         className="e-undo-view-close-overlay-button js-close-undo-dialog-button"
         onClick={close}
         tabIndex={0}
         role="button"
         aria-label={t('undo.close') as string}
-      />
+        width="30"
+        height="30"
+        viewBox="0 0 30 30"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect width="30" height="30" fill="#fff" opacity="0" />
+        <line x1="25" y1="5" x2="5" y2="25" fill="none" stroke="#6d6d6d" strokeMiterlimit="10" strokeWidth="3" />
+        <line x1="5" y1="5" x2="25" y2="25" fill="none" stroke="#6d6d6d" strokeMiterlimit="10" strokeWidth="3" />
+      </svg>
     </div>
   )
 }


### PR DESCRIPTION
Kokeen tekstivastausten vastaushistorianäkymä näyttää a2:ssa tältä 
<img width="185" height="125" alt="Screenshot 2025-07-17 at 12 01 45" src="https://github.com/user-attachments/assets/8ed56e84-644c-4d68-a001-28e844b91ec6" />
<img width="709" height="799" alt="Screenshot 2025-07-17 at 12 02 56" src="https://github.com/user-attachments/assets/627348d8-ae80-4f11-8bae-a6a5341691a6" />
<br>

johtunee siitä, että komponentissa UndoView on komponentti CloseButton, jossa on src-attribuuttina 'img/closeButton.svg' - tälläistä tiedostoa ei kuitenkaan ole koko ee:ssä! Se löytynee koe-reposta ja tämä bugi on tapahtunut, kun koe-reposta on siirretty tavaraa ee:seen ja tämä tiedosto on jäänyt huomioimatta.

Helpoin fiksi on mielestäni se, että tehdään closeButton.svg:stä react-komponentti svg-tagillä, silloin se tulee suoraan main-bundle.js:ään eikä koepakettiin tarvitse tunkea erikseen svg-tiedostoa.

Muuten kaikki hyvin, mutta en millään saanut ee:stä ulos koepakettia, jossa tekemäni muutos olisi mukana vaan aina tuli paketti, jossa oli vanha koodi missä viitattiin img/closeButton.svg:hen - en tiedä mikä siinä oli yritin npm ci, ajaa buildiä uudestaan jne. mun koneella ee preview ei myöskään toiminut! En saanut ennen lomaani fiksattua, jos joku saa varmistettua että tämä fiksi toimii niin tämän voi mergaa 🙏 