### PR TITLE
Add permanently unopenable filetype to attachments mex

### DIFF
--- a/packages/exams/AttachmentFiletypes/attachments/puppua.turska
+++ b/packages/exams/AttachmentFiletypes/attachments/puppua.turska
@@ -1,0 +1,1 @@
+Example of an unrecognized file format that does not open in Abitti

--- a/packages/exams/AttachmentFiletypes/filetypes.xml
+++ b/packages/exams/AttachmentFiletypes/filetypes.xml
@@ -37,6 +37,8 @@
                     <e:file src="ketcher.mol"/>
                     <br/>
                     <e:file src="certificate.pdf"/>
+                    <br/>
+                    <e:file src="puppua.turska"/>
                 </e:attachment>
             </e:external-material>
             <e:file src="python.py"/>
@@ -62,6 +64,8 @@
             <e:file src="drawio.drawio"/>
             <br/>
             <e:file src="certificate.pdf"/>
+            <br/>
+            <e:file src="puppua.turska"/>
             <e:text-answer type="rich-text" max-score="6"/>
         </e:question>
     </e:section>

--- a/packages/mastering/__tests__/__snapshots__/testExamMastering.ts.snap
+++ b/packages/mastering/__tests__/__snapshots__/testExamMastering.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Exam mastering generates correct grading structure for dnd answers 1`] = `
 {
@@ -25901,6 +25901,12 @@ exports[`Exam mastering masters filetypes.xml exam correctly 1`] = `
       "visibleInGradingInstructions": false,
       "withinGradingInstruction": false,
     },
+    {
+      "filename": "puppua.turska",
+      "restricted": false,
+      "visibleInGradingInstructions": false,
+      "withinGradingInstruction": false,
+    },
   ],
   "date": null,
   "dayCode": null,
@@ -25963,6 +25969,8 @@ exports[`Exam mastering masters filetypes.xml exam correctly: xml 1`] = `
                     <e:file src="ketcher.mol"/>
                     <br/>
                     <e:file src="certificate.pdf"/>
+                    <br/>
+                    <e:file src="puppua.turska"/>
                 </e:attachment>
             </e:external-material>
             <e:file src="python.py"/>
@@ -25988,6 +25996,8 @@ exports[`Exam mastering masters filetypes.xml exam correctly: xml 1`] = `
             <e:file src="drawio.drawio"/>
             <br/>
             <e:file src="certificate.pdf"/>
+            <br/>
+            <e:file src="puppua.turska"/>
             <e:text-answer type="rich-text" max-score="6" question-id="1" display-number="1"/>
         </e:question>
     </e:section>


### PR DESCRIPTION
Aiemmin, PDF-tiedostoa käytettiin semmoisen tiedoston esittämiseen, joka ei aukea Abitissa. Nyt PDF:ille tulee tuki, joten tarvitaan uusi tiedostotyyppi joka pysyvästi näyttelee sellaisen tiedoston roolia, jota Abitti ei tunnista ja jota se ei suostu avaamaan.