### PR TITLE
Filter non-element localization nodes

### DIFF
--- a/packages/mastering/src/mastering/index.ts
+++ b/packages/mastering/src/mastering/index.ts
@@ -719,14 +719,17 @@ function applyEditableLocalization(
   type: ExamType,
   parentLocalization?: Element
 ) {
-  // traverse children first
-  localization.childNodes().forEach(node => {
-    const child = node as Element
-    const childName = child.name()
-    if (childName == 'localization') {
-      applyEditableLocalization(child, language, type, localization)
-    }
-  })
+  // traverse child elements first
+  localization
+    .childNodes()
+    .filter(node => node.type() == 'element')
+    .forEach(node => {
+      const child = node as Element
+      const childName = child.name()
+      if (childName == 'localization') {
+        applyEditableLocalization(child, language, type, localization)
+      }
+    })
 
   // ProseMirrors makes flat localizations, so take parent attributes for children to preverve them
   if (parentLocalization) {


### PR DESCRIPTION
Non-element children cause HVP editing to crash, as `Text` and `Comment` node types do not have a `.name()` function (libxmljs2 types). In addition to casting the node `as Element` like before, filter out all non-element nodes. Function is only called when `editableGradingInstructions === true`, i.e. when HVP is being edited.