### PR TITLE
Update RTE to 8.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25342,9 +25342,9 @@
       }
     },
     "node_modules/rich-text-editor": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/rich-text-editor/-/rich-text-editor-8.11.0.tgz",
-      "integrity": "sha512-zlhITZI30+DnV6FcHOJVLW6NZxK/WAqLeNB3rYGlyukezWKlz+2O7bTUW5CpV4TMECtwuiVJAPF69ijmQ16Jrw==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/rich-text-editor/-/rich-text-editor-8.11.2.tgz",
+      "integrity": "sha512-5NtMGMGTnPDUqXBpVcHZzClxqx31EUUAXmig7EZO+6YqAS2d9WYSouzM0F7ksJPcknpIAOoGRE3YZgwe5j9OKQ==",
       "dependencies": {
         "@digabi/mathquill": "^0.10.12",
         "@types/jquery": "^4.0.0",
@@ -29636,7 +29636,7 @@
         "@digabi/exam-engine-rendering": "23.25.0",
         "lodash": "^4.18.1",
         "ora": "^5.0.0",
-        "rich-text-editor": "^8.11.0",
+        "rich-text-editor": "^8.11.2",
         "uuid": "^14.0.0",
         "yargs": "^18.0.0"
       },
@@ -29798,7 +29798,7 @@
         "redux": "^5.0.1",
         "redux-saga": "^1.5.0",
         "redux-saga-test-plan": "^4.0.6",
-        "rich-text-editor": "^8.11.0",
+        "rich-text-editor": "^8.11.2",
         "sanitize-html": "^2.17.4",
         "typesafe-actions": "^5.1.0",
         "utility-types": "^3.10.0",
@@ -29968,7 +29968,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router5": "^8.0.1",
-        "rich-text-editor": "^8.11.0",
+        "rich-text-editor": "^8.11.2",
         "router5": "^8.0.1",
         "router5-plugin-browser": "^8.0.1",
         "tmp-promise": "^3.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "@digabi/exam-engine-rendering": "23.25.0",
     "lodash": "^4.18.1",
     "ora": "^5.0.0",
-    "rich-text-editor": "^8.11.0",
+    "rich-text-editor": "^8.11.2",
     "uuid": "^14.0.0",
     "yargs": "^18.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "redux": "^5.0.1",
     "redux-saga": "^1.5.0",
     "redux-saga-test-plan": "^4.0.6",
-    "rich-text-editor": "^8.11.0",
+    "rich-text-editor": "^8.11.2",
     "sanitize-html": "^2.17.4",
     "typesafe-actions": "^5.1.0",
     "utility-types": "^3.10.0",

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -34,7 +34,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router5": "^8.0.1",
-    "rich-text-editor": "^8.11.0",
+    "rich-text-editor": "^8.11.2",
     "router5": "^8.0.1",
     "router5-plugin-browser": "^8.0.1",
     "tmp-promise": "^3.0.2",


### PR DESCRIPTION
RTE 8.11.1 korjaa sen, että kuvaa edeltävää rivinvaihtoa ei poisteta 