### PR TITLE
Add dedicated warning when an answer is too long to save

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,7 @@ jobs:
           path: ~/.cache/puppeteer
           key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - run: npm install-scripts ls
-
-      - run: npm rebuild full-icu libxmljs2
+      - run: npm rebuild full-icu
 
       - name: Run Jest Tests
         run: npm run test-jest -- --ci
@@ -46,8 +44,6 @@ jobs:
 
       - name: Install Specific Playwright Browsers (Chromium and Firefox)
         run: npx playwright install chromium firefox
-
-      - run: npm rebuild full-icu libxmljs2
 
       - name: Run Playwright Component Tests
         run: CI=true npm run test-ct

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,10 @@ jobs:
           path: ~/.cache/puppeteer
           key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - run: npm rebuild full-icu
-    
+      - run: npm install-scripts ls
+
+      - run: npm rebuild full-icu libxmljs2
+
       - name: Run Jest Tests
         run: npm run test-jest -- --ci
 
@@ -44,6 +46,8 @@ jobs:
 
       - name: Install Specific Playwright Browsers (Chromium and Firefox)
         run: npx playwright install chromium firefox
+
+      - run: npm rebuild full-icu libxmljs2
 
       - name: Run Playwright Component Tests
         run: CI=true npm run test-ct

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - run: npm rebuild full-icu
-
+    
       - name: Run Jest Tests
         run: npm run test-jest -- --ci
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "npm",
   "packages": ["packages/*"],
-  "version": "23.27.0-alpha.0",
+  "version": "23.27.0",
   "exact": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "npm",
   "packages": ["packages/*"],
-  "version": "23.26.0",
+  "version": "23.27.0-alpha.0",
   "exact": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29064,11 +29064,11 @@
     },
     "packages/cli": {
       "name": "@digabi/exam-engine-cli",
-      "version": "23.27.0-alpha.0",
+      "version": "23.27.0",
       "license": "EUPL-1.1",
       "dependencies": {
-        "@digabi/exam-engine-mastering": "23.27.0-alpha.0",
-        "@digabi/exam-engine-rendering": "23.27.0-alpha.0",
+        "@digabi/exam-engine-mastering": "23.27.0",
+        "@digabi/exam-engine-rendering": "23.27.0",
         "lodash": "^4.18.1",
         "ora": "^5.0.0",
         "rich-text-editor": "^8.11.2",
@@ -29200,7 +29200,7 @@
     },
     "packages/core": {
       "name": "@digabi/exam-engine-core",
-      "version": "23.27.0-alpha.0",
+      "version": "23.27.0",
       "license": "EUPL-1.1",
       "devDependencies": {
         "@digabi/mathquill": "^0.10.12",
@@ -29339,28 +29339,28 @@
     },
     "packages/exams": {
       "name": "@digabi/exam-engine-exams",
-      "version": "23.27.0-alpha.0",
+      "version": "23.27.0",
       "license": "EUPL-1.1",
       "dependencies": {
-        "@digabi/exam-engine-mastering": "23.27.0-alpha.0"
+        "@digabi/exam-engine-mastering": "23.27.0"
       }
     },
     "packages/generator": {
       "name": "@digabi/exam-engine-generator",
-      "version": "23.27.0-alpha.0",
+      "version": "23.27.0",
       "license": "EUPL-1.1",
       "dependencies": {
-        "@digabi/exam-engine-core": "23.27.0-alpha.0",
+        "@digabi/exam-engine-core": "23.27.0",
         "libxmljs2": "^0.37.0",
         "lodash": "^4.18.1"
       }
     },
     "packages/mastering": {
       "name": "@digabi/exam-engine-mastering",
-      "version": "23.27.0-alpha.0",
+      "version": "23.27.0",
       "license": "EUPL-1.1",
       "dependencies": {
-        "@digabi/exam-engine-core": "23.27.0-alpha.0",
+        "@digabi/exam-engine-core": "23.27.0",
         "@ffprobe-installer/ffprobe": "^2.0.0",
         "cloneable-readable": "^3.0.0",
         "compare-versions": "^6.0.0",
@@ -29374,7 +29374,7 @@
     },
     "packages/rendering": {
       "name": "@digabi/exam-engine-rendering",
-      "version": "23.27.0-alpha.0",
+      "version": "23.27.0",
       "license": "EUPL-1.1",
       "dependencies": {
         "@babel/core": "^8.0.1",
@@ -29382,7 +29382,7 @@
         "@babel/polyfill": "^7.8.7",
         "@babel/preset-env": "^8.0.2",
         "@babel/runtime": "^8.0.0",
-        "@digabi/exam-engine-core": "23.27.0-alpha.0",
+        "@digabi/exam-engine-core": "23.27.0",
         "@fortawesome/fontawesome-svg-core": "^7.3.0",
         "babel-loader": "^10.0.0",
         "css-loader": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29064,11 +29064,11 @@
     },
     "packages/cli": {
       "name": "@digabi/exam-engine-cli",
-      "version": "23.26.0",
+      "version": "23.27.0-alpha.0",
       "license": "EUPL-1.1",
       "dependencies": {
-        "@digabi/exam-engine-mastering": "23.26.0",
-        "@digabi/exam-engine-rendering": "23.26.0",
+        "@digabi/exam-engine-mastering": "23.27.0-alpha.0",
+        "@digabi/exam-engine-rendering": "23.27.0-alpha.0",
         "lodash": "^4.18.1",
         "ora": "^5.0.0",
         "rich-text-editor": "^8.11.2",
@@ -29200,7 +29200,7 @@
     },
     "packages/core": {
       "name": "@digabi/exam-engine-core",
-      "version": "23.26.0",
+      "version": "23.27.0-alpha.0",
       "license": "EUPL-1.1",
       "devDependencies": {
         "@digabi/mathquill": "^0.10.12",
@@ -29339,28 +29339,28 @@
     },
     "packages/exams": {
       "name": "@digabi/exam-engine-exams",
-      "version": "23.26.0",
+      "version": "23.27.0-alpha.0",
       "license": "EUPL-1.1",
       "dependencies": {
-        "@digabi/exam-engine-mastering": "23.26.0"
+        "@digabi/exam-engine-mastering": "23.27.0-alpha.0"
       }
     },
     "packages/generator": {
       "name": "@digabi/exam-engine-generator",
-      "version": "23.26.0",
+      "version": "23.27.0-alpha.0",
       "license": "EUPL-1.1",
       "dependencies": {
-        "@digabi/exam-engine-core": "23.26.0",
+        "@digabi/exam-engine-core": "23.27.0-alpha.0",
         "libxmljs2": "^0.37.0",
         "lodash": "^4.18.1"
       }
     },
     "packages/mastering": {
       "name": "@digabi/exam-engine-mastering",
-      "version": "23.26.0",
+      "version": "23.27.0-alpha.0",
       "license": "EUPL-1.1",
       "dependencies": {
-        "@digabi/exam-engine-core": "23.26.0",
+        "@digabi/exam-engine-core": "23.27.0-alpha.0",
         "@ffprobe-installer/ffprobe": "^2.0.0",
         "cloneable-readable": "^3.0.0",
         "compare-versions": "^6.0.0",
@@ -29374,7 +29374,7 @@
     },
     "packages/rendering": {
       "name": "@digabi/exam-engine-rendering",
-      "version": "23.26.0",
+      "version": "23.27.0-alpha.0",
       "license": "EUPL-1.1",
       "dependencies": {
         "@babel/core": "^8.0.1",
@@ -29382,7 +29382,7 @@
         "@babel/polyfill": "^7.8.7",
         "@babel/preset-env": "^8.0.2",
         "@babel/runtime": "^8.0.0",
-        "@digabi/exam-engine-core": "23.26.0",
+        "@digabi/exam-engine-core": "23.27.0-alpha.0",
         "@fortawesome/fontawesome-svg-core": "^7.3.0",
         "babel-loader": "^10.0.0",
         "css-loader": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -77,5 +77,10 @@
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@playwright/experimental-ct-react": "^1.53.0"
+  },
+  "allowScripts": {
+    "libxmljs2@0.37.0": true,
+    "@ffprobe-installer/linux-x64@5.2.0": true,
+    "full-icu@1.6.0": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "allowScripts": {
     "libxmljs2@0.37.0": true,
     "@ffprobe-installer/linux-x64@5.2.0": true,
-    "full-icu@1.6.0": true
+    "full-icu@1.6.0": true,
+    "puppeteer@25.2.1": true
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-cli",
-  "version": "23.27.0-alpha.0",
+  "version": "23.27.0",
   "main": "index.js",
   "repository": "https://github.com/digabi/exam-engine",
   "license": "EUPL-1.1",
@@ -11,8 +11,8 @@
     "ee": "./dist/index.js"
   },
   "dependencies": {
-    "@digabi/exam-engine-mastering": "23.27.0-alpha.0",
-    "@digabi/exam-engine-rendering": "23.27.0-alpha.0",
+    "@digabi/exam-engine-mastering": "23.27.0",
+    "@digabi/exam-engine-rendering": "23.27.0",
     "lodash": "^4.18.1",
     "ora": "^5.0.0",
     "rich-text-editor": "^8.11.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-cli",
-  "version": "23.26.0",
+  "version": "23.27.0-alpha.0",
   "main": "index.js",
   "repository": "https://github.com/digabi/exam-engine",
   "license": "EUPL-1.1",
@@ -11,8 +11,8 @@
     "ee": "./dist/index.js"
   },
   "dependencies": {
-    "@digabi/exam-engine-mastering": "23.26.0",
-    "@digabi/exam-engine-rendering": "23.26.0",
+    "@digabi/exam-engine-mastering": "23.27.0-alpha.0",
+    "@digabi/exam-engine-rendering": "23.27.0-alpha.0",
     "lodash": "^4.18.1",
     "ora": "^5.0.0",
     "rich-text-editor": "^8.11.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-core",
-  "version": "23.27.0-alpha.0",
+  "version": "23.27.0",
   "main": "dist/main-bundle.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/digabi/exam-engine",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-core",
-  "version": "23.26.0",
+  "version": "23.27.0-alpha.0",
   "main": "dist/main-bundle.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/digabi/exam-engine",

--- a/packages/core/src/components/AnswerToolbar.tsx
+++ b/packages/core/src/components/AnswerToolbar.tsx
@@ -11,6 +11,7 @@ interface AnswerToolbarProps {
   answer?: TextAnswer | RichTextAnswer
   screenshotError?: ScreenshotError
   validationError?: AnswerTooLong
+  tooLongSaveFailure?: boolean
   element: Element
   selectAnswerVersion?: typeof actions.selectAnswerVersion
   showAnswerHistory?: boolean
@@ -22,6 +23,7 @@ function AnswerToolbar({
   element,
   screenshotError,
   validationError,
+  tooLongSaveFailure,
   selectAnswerVersion,
   showAnswerHistory = false,
   supportsAnswerHistory = false
@@ -45,10 +47,15 @@ function AnswerToolbar({
             {' '}
             {t(`answer-errors.${screenshotError.key}` as const, screenshotError.options)}
           </span>
-        ) : validationError ? (
+        ) : validationError && !tooLongSaveFailure ? (
           // We don't use an alert role here because ErrorIndicator already displays the same error message wrapped in an alert role
           <span> {t(`answer-errors.answer-too-long`, { count: validationError.characterCount })}</span>
         ) : null}
+        {tooLongSaveFailure && (
+          <div className="answer-toolbar__save-failed e-color-error" role="alert">
+            {t('answer-errors.answer-too-long-not-saved')}
+          </div>
+        )}
       </div>
       <div className="answer-toolbar__history e-column e-column--narrow e-text-right">
         {supportsAnswerHistory && (

--- a/packages/core/src/components/exam/RichTextAnswer.tsx
+++ b/packages/core/src/components/exam/RichTextAnswer.tsx
@@ -1,5 +1,4 @@
 import { TOptions } from 'i18next'
-import * as _ from 'lodash-es'
 import React from 'react'
 import { RichTextAnswer as RichTextAnswerT } from '../../types/ExamAnswer'
 import { CommonExamContext } from '../context/CommonExamContext'
@@ -14,7 +13,7 @@ export interface ScreenshotError {
   options?: TOptions
 }
 
-type ErrorResponse = { response: { status: number } } & Error
+type ErrorResponse = { statusCode?: number; status?: number } & Error
 
 interface Props {
   answer?: RichTextAnswerT
@@ -42,7 +41,7 @@ export default class RichTextAnswer extends React.PureComponent<Props> {
 
   handleSaveError = (err: ErrorResponse): void => {
     const key = (() => {
-      switch (_.get(err, 'response.status')) {
+      switch (err.statusCode ?? err.status) {
         case 409:
           return 'screenshot-byte-limit-reached'
         case 413:

--- a/packages/core/src/components/exam/internal/ErrorIndicator.tsx
+++ b/packages/core/src/components/exam/internal/ErrorIndicator.tsx
@@ -31,11 +31,22 @@ const AnswerTooLongError: React.FunctionComponent<AnswerTooLong> = ({ displayNum
     </div>
   )
 }
+
+interface SaveFailedTooLong {
+  type: 'SaveFailedTooLong'
+  displayNumber: string
+}
+
+const SaveFailedTooLongError: React.FunctionComponent<SaveFailedTooLong> = ({ displayNumber }) => {
+  const { t } = useExamTranslation()
+  return <div>{t('answer-errors.save-failed-too-long', { displayNumber })}</div>
+}
+
 export function ErrorIndicatorForErrors({
   validationErrors,
   inExam
 }: {
-  validationErrors: ValidationError[]
+  validationErrors: (ValidationError | SaveFailedTooLong)[]
   inExam: boolean
 }) {
   return validationErrors.length > 0 ? (
@@ -57,6 +68,8 @@ export function ErrorIndicatorForErrors({
         {validationErrors.map(validationError => {
           const key = validationError.type + validationError.displayNumber
           switch (validationError.type) {
+            case 'SaveFailedTooLong':
+              return <SaveFailedTooLongError {...{ ...validationError, key }} />
             case 'ExtraAnswer':
               return <ExtraAnswerError {...{ ...validationError, key }} />
             default:
@@ -67,8 +80,23 @@ export function ErrorIndicatorForErrors({
     </dialog>
   ) : null
 }
+
+const mergeErrors = (state: AnswersState): (ValidationError | SaveFailedTooLong)[] => {
+  const saveFailedErrors = [...state.answerTooLongFailures].flatMap(questionId => {
+    const displayNumber = state.answersById[questionId]?.displayNumber
+    return displayNumber != null ? [{ type: 'SaveFailedTooLong' as const, displayNumber }] : []
+  })
+
+  // Prioritize save failed errors; filter out validation errors if there's a save failed error for the same question.
+  const otherErrors = state.validationErrors.filter(
+    error => !saveFailedErrors.some(saveFailedError => saveFailedError.displayNumber === error.displayNumber)
+  )
+
+  return [...otherErrors, ...saveFailedErrors]
+}
+
 const ErrorIndicator: React.FunctionComponent = () => {
-  const validationErrors = useSelector((state: { answers: AnswersState }) => state.answers.validationErrors)
+  const validationErrors = useSelector((state: { answers: AnswersState }) => mergeErrors(state.answers))
   return <ErrorIndicatorForErrors validationErrors={validationErrors} inExam={true} />
 }
 

--- a/packages/core/src/components/exam/internal/SaveIndicator.tsx
+++ b/packages/core/src/components/exam/internal/SaveIndicator.tsx
@@ -10,19 +10,13 @@ function SaveIndicator() {
   const tooLongFailureDisplayNumber = useSelector(getAnyAnswerTooLongFailure)
   const { t } = useExamTranslation()
 
-  if (state === 'initial' && !tooLongFailureDisplayNumber) {
+  if (state === 'initial' || tooLongFailureDisplayNumber) {
     return null
   }
 
   return (
     <dialog open className="save-indicator e-pad-1 e-font-size-xs">
-      {tooLongFailureDisplayNumber ? (
-        <span className="save-indicator-text" role="alert">
-          {t('answer-errors.save-failed-too-long', { displayNumber: tooLongFailureDisplayNumber })}
-        </span>
-      ) : (
-        <span className={classNames('save-indicator-text', `save-indicator-text--${state}`)}>{t('answer-saved')}</span>
-      )}
+      <span className={classNames('save-indicator-text', `save-indicator-text--${state}`)}>{t('answer-saved')}</span>
     </dialog>
   )
 }

--- a/packages/core/src/components/exam/internal/SaveIndicator.tsx
+++ b/packages/core/src/components/exam/internal/SaveIndicator.tsx
@@ -3,19 +3,26 @@ import React from 'react'
 import { useSelector } from 'react-redux'
 import { SaveState } from '../../../index'
 import { useExamTranslation } from '../../../i18n'
-import { getSaveState } from '../../../store/selectors'
+import { getAnyAnswerTooLongFailure, getSaveState } from '../../../store/selectors'
 
 function SaveIndicator() {
   const state: SaveState = useSelector(getSaveState)
+  const tooLongFailureDisplayNumber = useSelector(getAnyAnswerTooLongFailure)
   const { t } = useExamTranslation()
 
-  if (state === 'initial') {
+  if (state === 'initial' && !tooLongFailureDisplayNumber) {
     return null
   }
 
   return (
     <dialog open className="save-indicator e-pad-1 e-font-size-xs">
-      <span className={classNames('save-indicator-text', `save-indicator-text--${state}`)}>{t('answer-saved')}</span>
+      {tooLongFailureDisplayNumber ? (
+        <span className="save-indicator-text" role="alert">
+          {t('answer-errors.save-failed-too-long', { displayNumber: tooLongFailureDisplayNumber })}
+        </span>
+      ) : (
+        <span className={classNames('save-indicator-text', `save-indicator-text--${state}`)}>{t('answer-saved')}</span>
+      )}
     </dialog>
   )
 }

--- a/packages/core/src/components/exam/internal/TextAnswerInput.tsx
+++ b/packages/core/src/components/exam/internal/TextAnswerInput.tsx
@@ -15,6 +15,7 @@ import AnswerLengthInfo from '../../shared/AnswerLengthInfo'
 import { CommonExamContext } from '../../context/CommonExamContext'
 import { answerBlurred, answerFocused, saveAnswer, selectAnswerVersion } from '../../../store/answers/actions'
 import { AnswersState } from '../../../store/answers/reducer'
+import { getAnswerTooLongFailure } from '../../../store/selectors'
 
 const borderWidthPx = 2
 
@@ -48,6 +49,8 @@ const TextAnswerInput: React.FunctionComponent<ExamComponentProps> = ({ element,
       (error): error is AnswerTooLong => error.type === 'AnswerTooLong' && error.displayNumber === displayNumber
     )
   )
+
+  const tooLongSaveFailure = useSelector(getAnswerTooLongFailure(questionId))
 
   const dispatch = useDispatch()
   const ref = useRef<HTMLInputElement & HTMLTextAreaElement>(null)
@@ -170,7 +173,8 @@ const TextAnswerInput: React.FunctionComponent<ExamComponentProps> = ({ element,
                 showAnswerHistory,
                 supportsAnswerHistory,
                 screenshotError,
-                validationError
+                validationError,
+                tooLongSaveFailure
               }}
             />
           </div>

--- a/packages/core/src/i18n/fi-FI.ts
+++ b/packages/core/src/i18n/fi-FI.ts
@@ -211,7 +211,9 @@ export const fi_FI = {
     'screenshot-byte-limit-reached':
       'Kokeesi kuvakaappauksille varattu tila on täyttynyt. (Voit viitata aineistokuviin suoraan ilman kuvakaappausta.)',
     'screenshot-upload-failed': 'Kuvan liittäminen ei onnistunut. Kokeile uudestaan.',
-    'answer-too-long': 'Vastaus on liian pitkä.'
+    'answer-too-long': 'Vastaus on liian pitkä.',
+    'answer-too-long-not-saved': 'Vastaus on liian pitkä eikä sitä voitu tallentaa. Muokkaa vastaustasi lyhyemmäksi.',
+    'save-failed-too-long': 'Tallentaminen ei onnistunut. Liian pitkä vastaus tehtävässä {{displayNumber}}.'
   },
   'screen-reader': {
     'answer-begin': '[Vastaus alkaa]',

--- a/packages/core/src/i18n/sv-FI.ts
+++ b/packages/core/src/i18n/sv-FI.ts
@@ -204,7 +204,9 @@ export const sv_FI: Translations = {
     'screenshot-byte-limit-reached':
       'Minnesutrymmet för skärmdumpar är fullt. (Du kan referera till bilder i materialet direkt utan skärmdumpar.)',
     'screenshot-upload-failed': 'Bifogandet av skärmdumpen misslyckades. Försök på nytt.',
-    'answer-too-long': 'Svaret är för långt.'
+    'answer-too-long': 'Svaret är för långt.',
+    'answer-too-long-not-saved': 'Svaret är för långt och kunde inte sparas. Gör ditt svar kortare.',
+    'save-failed-too-long': 'Sparandet misslyckades. För långt svar i uppgift {{displayNumber}}.'
   },
   'screen-reader': {
     'answer-begin': '[Svaret börjar]',

--- a/packages/core/src/store/answers/reducer.ts
+++ b/packages/core/src/store/answers/reducer.ts
@@ -22,6 +22,11 @@ export interface AnswersState {
    */
   serverQuestionIds: Set<QuestionId>
   /**
+   * The set of questions whose most recent save attempt was rejected by the
+   * server because the answer was too long.
+   */
+  answerTooLongFailures: Set<QuestionId>
+  /**
    * Whether or not the Exam API has implemented the optional answer history
    * feature. For now, only the real ktp has implemented it. it.
    */
@@ -48,6 +53,7 @@ const initialState: AnswersState = {
   supportsAnswerHistory: false,
   serverQuestionIds: new Set(),
   savedQuestionIds: new Set(),
+  answerTooLongFailures: new Set(),
   validationErrors: []
 }
 
@@ -56,10 +62,16 @@ export default function answersReducer(state: AnswersState = initialState, actio
     case 'SAVE_ANSWER': {
       const { questionId } = action.payload
       const synchronizedQuestionIds = setDelete(state.savedQuestionIds, questionId)
+      const answerTooLongFailures = setDelete(state.answerTooLongFailures, questionId)
       const answersById = { ...state.answersById, [questionId]: action.payload }
-      return { ...state, savedQuestionIds: synchronizedQuestionIds, answersById }
+      return { ...state, savedQuestionIds: synchronizedQuestionIds, answerTooLongFailures, answersById }
     }
     case 'SAVE_ANSWER_FAILED': {
+      const { answer, error } = action.payload
+      if (error instanceof Error && error.message === 'answer-too-long') {
+        const answerTooLongFailures = setAdd(state.answerTooLongFailures, answer.questionId)
+        return { ...state, answerTooLongFailures }
+      }
       return state
     }
     case 'SAVE_ANSWER_SUCCEEDED': {

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -55,6 +55,7 @@ export function initializeExamStore(
       serverQuestionIds: initialQuestionIds,
       supportsAnswerHistory: typeof examServerApi.selectAnswerVersion === 'function',
       savedQuestionIds: initialQuestionIds,
+      answerTooLongFailures: new Set(),
       examStructure,
       validationErrors: validateAnswers(examStructure, answersById)
     },

--- a/packages/core/src/store/selectors.ts
+++ b/packages/core/src/store/selectors.ts
@@ -60,3 +60,14 @@ function containsAnswerNotYetSavedInServer(
   }
   return false
 }
+
+export const getAnswerTooLongFailure =
+  (questionId: QuestionId) =>
+  (state: AppState): boolean =>
+    state.answers.answerTooLongFailures.has(questionId)
+
+export const getAnyAnswerTooLongFailure = (state: AppState): string | undefined => {
+  const { answerTooLongFailures, answersById } = state.answers
+  const [questionId] = answerTooLongFailures
+  return answersById[questionId]?.displayNumber
+}

--- a/packages/core/src/types/ExamServerAPI.ts
+++ b/packages/core/src/types/ExamServerAPI.ts
@@ -1,6 +1,9 @@
 import { AnswerHistoryEntry, ExamAnswer, QuestionId } from './ExamAnswer'
 
 export type SaveState = 'initial' | 'saving' | 'saved'
+
+export type SaveAnswerError = 'answer-too-long'
+
 /**
  * CAS status is a state machine with three states.
  *

--- a/packages/exams/package.json
+++ b/packages/exams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-exams",
-  "version": "23.27.0-alpha.0",
+  "version": "23.27.0",
   "repository": "https://github.com/digabi/exam-engine",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.1",
@@ -14,7 +14,7 @@
     "prepublishOnly": "find . -name '*.mex' -delete && find . -name '*.xml' -print0 | xargs -0 -n1 -P4 node ../cli/dist/index.js create-mex -p salasana -n nsa-scripts.zip -s security-codes.json -k exam_key.pem"
   },
   "dependencies": {
-    "@digabi/exam-engine-mastering": "23.27.0-alpha.0"
+    "@digabi/exam-engine-mastering": "23.27.0"
   },
   "gitHead": "38106fd91e7fab82ac4fdc9230c70ee4c8e29278"
 }

--- a/packages/exams/package.json
+++ b/packages/exams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-exams",
-  "version": "23.26.0",
+  "version": "23.27.0-alpha.0",
   "repository": "https://github.com/digabi/exam-engine",
   "author": "Matriculation Examination Board, Finland",
   "license": "EUPL-1.1",
@@ -14,7 +14,7 @@
     "prepublishOnly": "find . -name '*.mex' -delete && find . -name '*.xml' -print0 | xargs -0 -n1 -P4 node ../cli/dist/index.js create-mex -p salasana -n nsa-scripts.zip -s security-codes.json -k exam_key.pem"
   },
   "dependencies": {
-    "@digabi/exam-engine-mastering": "23.26.0"
+    "@digabi/exam-engine-mastering": "23.27.0-alpha.0"
   },
   "gitHead": "38106fd91e7fab82ac4fdc9230c70ee4c8e29278"
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-generator",
-  "version": "23.27.0-alpha.0",
+  "version": "23.27.0",
   "main": "dist/index.js",
   "repository": "https://github.com/digabi/exam-engine",
   "author": "Matriculation Examination Board, Finland",
@@ -9,7 +9,7 @@
     "dist"
   ],
   "dependencies": {
-    "@digabi/exam-engine-core": "23.27.0-alpha.0",
+    "@digabi/exam-engine-core": "23.27.0",
     "libxmljs2": "^0.37.0",
     "lodash": "^4.18.1"
   },

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-generator",
-  "version": "23.26.0",
+  "version": "23.27.0-alpha.0",
   "main": "dist/index.js",
   "repository": "https://github.com/digabi/exam-engine",
   "author": "Matriculation Examination Board, Finland",
@@ -9,7 +9,7 @@
     "dist"
   ],
   "dependencies": {
-    "@digabi/exam-engine-core": "23.26.0",
+    "@digabi/exam-engine-core": "23.27.0-alpha.0",
     "libxmljs2": "^0.37.0",
     "lodash": "^4.18.1"
   },

--- a/packages/mastering/package.json
+++ b/packages/mastering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-mastering",
-  "version": "23.26.0",
+  "version": "23.27.0-alpha.0",
   "main": "dist/index.js",
   "repository": "https://github.com/digabi/exam-engine",
   "author": "Matriculation Examination Board, Finland",
@@ -10,7 +10,7 @@
     "schema"
   ],
   "dependencies": {
-    "@digabi/exam-engine-core": "23.26.0",
+    "@digabi/exam-engine-core": "23.27.0-alpha.0",
     "@ffprobe-installer/ffprobe": "^2.0.0",
     "cloneable-readable": "^3.0.0",
     "compare-versions": "^6.0.0",

--- a/packages/mastering/package.json
+++ b/packages/mastering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-mastering",
-  "version": "23.27.0-alpha.0",
+  "version": "23.27.0",
   "main": "dist/index.js",
   "repository": "https://github.com/digabi/exam-engine",
   "author": "Matriculation Examination Board, Finland",
@@ -10,7 +10,7 @@
     "schema"
   ],
   "dependencies": {
-    "@digabi/exam-engine-core": "23.27.0-alpha.0",
+    "@digabi/exam-engine-core": "23.27.0",
     "@ffprobe-installer/ffprobe": "^2.0.0",
     "cloneable-readable": "^3.0.0",
     "compare-versions": "^6.0.0",

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-rendering",
-  "version": "23.26.0",
+  "version": "23.27.0-alpha.0",
   "main": "./dist/index.js",
   "repository": "https://github.com/digabi/exam-engine",
   "license": "EUPL-1.1",
@@ -14,7 +14,7 @@
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^8.0.2",
     "@babel/runtime": "^8.0.0",
-    "@digabi/exam-engine-core": "23.26.0",
+    "@digabi/exam-engine-core": "23.27.0-alpha.0",
     "@fortawesome/fontawesome-svg-core": "^7.3.0",
     "babel-loader": "^10.0.0",
     "css-loader": "^7.0.0",

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digabi/exam-engine-rendering",
-  "version": "23.27.0-alpha.0",
+  "version": "23.27.0",
   "main": "./dist/index.js",
   "repository": "https://github.com/digabi/exam-engine",
   "license": "EUPL-1.1",
@@ -14,7 +14,7 @@
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^8.0.2",
     "@babel/runtime": "^8.0.0",
-    "@digabi/exam-engine-core": "23.27.0-alpha.0",
+    "@digabi/exam-engine-core": "23.27.0",
     "@fortawesome/fontawesome-svg-core": "^7.3.0",
     "babel-loader": "^10.0.0",
     "css-loader": "^7.0.0",


### PR DESCRIPTION
Related: https://github.com/digabi/digabi2/pull/2087

- Add dedicated warning when an answer is too long to save
- Fix issue with screenshot validation errors not being surfaced due to wrong error response type
- Fix CI tests not working due to libxmljs2 error: `Could not locate the bindings file`
  - Since npm 12, npm doesn't allow dependencies to run scripts by default. Added some needed dependencies to `allowScripts` so that their install/postinstall scripts can run in CI
