### PR TITLE
Rich text undo and redo move one edit at a time, not one character

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25006,9 +25006,9 @@
       }
     },
     "node_modules/rich-text-editor": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/rich-text-editor/-/rich-text-editor-8.11.2.tgz",
-      "integrity": "sha512-5NtMGMGTnPDUqXBpVcHZzClxqx31EUUAXmig7EZO+6YqAS2d9WYSouzM0F7ksJPcknpIAOoGRE3YZgwe5j9OKQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/rich-text-editor/-/rich-text-editor-8.13.0.tgz",
+      "integrity": "sha512-md/LRdMadE8GkQxlT9Fba0LYwviw+bbYFPivx8SnCExlgFdznPuPhG/21XVdoJua8DKrweLsaL8Ije0VbrQFww==",
       "dependencies": {
         "@digabi/mathquill": "^0.10.12",
         "@types/jquery": "^4.0.0",
@@ -29275,7 +29275,7 @@
         "@digabi/exam-engine-rendering": "23.27.0",
         "lodash": "^4.18.1",
         "ora": "^5.0.0",
-        "rich-text-editor": "^8.11.2",
+        "rich-text-editor": "^8.12.0",
         "uuid": "^14.0.0",
         "yargs": "^18.1.0"
       },
@@ -29453,7 +29453,7 @@
         "redux": "^5.0.1",
         "redux-saga": "^1.5.1",
         "redux-saga-test-plan": "^4.0.6",
-        "rich-text-editor": "^8.11.2",
+        "rich-text-editor": "^8.12.0",
         "sanitize-html": "^2.17.6",
         "typesafe-actions": "^5.1.0",
         "utility-types": "^3.10.0",
@@ -29622,7 +29622,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router5": "^8.0.1",
-        "rich-text-editor": "^8.11.2",
+        "rich-text-editor": "^8.12.0",
         "router5": "^8.0.1",
         "router5-plugin-browser": "^8.0.1",
         "tmp-promise": "^3.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "@digabi/exam-engine-rendering": "23.27.0",
     "lodash": "^4.18.1",
     "ora": "^5.0.0",
-    "rich-text-editor": "^8.11.2",
+    "rich-text-editor": "^8.12.0",
     "uuid": "^14.0.0",
     "yargs": "^18.1.0"
   },

--- a/packages/core/__tests__/playwright/exam/TextAnswerInput.test.tsx
+++ b/packages/core/__tests__/playwright/exam/TextAnswerInput.test.tsx
@@ -6,15 +6,44 @@ test.describe('TextAnswerInput', () => {
   test('integer input accepts unicode minus sign', async ({ mount }) => {
     const component = await mount(<QuestionStory examXml={examXml} />)
     await component.locator('input').type('−5')
-    await expect(component.locator('input')).toHaveValue('\u22125')
+    await expect(component.locator('input')).toHaveValue('−5')
   })
 
   test('integer input accepts ascii hyphen minus sign', async ({ mount }) => {
     const component = await mount(<QuestionStory examXml={examXml} />)
     await component.locator('input').type('-5')
-    await expect(component.locator('input')).toHaveValue('\u002D5')
+    await expect(component.locator('input')).toHaveValue('-5')
+  })
+
+  test('rich text undo and redo move a whole debounced edit at a time', async ({ mount, page }) => {
+    // The editor's answer history is debounced by 500 ms, so everything typed within a
+    // single burst must be undone and redone as one step, not character by character.
+    const historyTimeout = 550
+    const component = await mount(<QuestionStory examXml={richTextExamXml} />)
+    const editor = component.getByTestId('rich-text-editor')
+
+    await editor.click()
+    await page.keyboard.type('aa')
+    await page.waitForTimeout(historyTimeout)
+    await page.keyboard.type('bb')
+    await page.waitForTimeout(historyTimeout)
+    await expect(editor).toHaveText('aabb')
+
+    await page.keyboard.press('ControlOrMeta+z')
+    await expect(editor).toHaveText('aa')
+
+    await page.keyboard.press('ControlOrMeta+z')
+    await expect(editor).toHaveText('')
+
+    await page.keyboard.press(redoShortcut)
+    await expect(editor).toHaveText('aa')
+
+    await page.keyboard.press(redoShortcut)
+    await expect(editor).toHaveText('aabb')
   })
 })
+
+const redoShortcut = process.platform === 'darwin' ? 'Meta+Shift+z' : 'Control+y'
 
 const examXml = `<e:exam xmlns:e="http://ylioppilastutkinto.fi/exam.xsd" xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ylioppilastutkinto.fi/exam.xsd https://abitti.net/schema/exam.xsd" exam-schema-version="0.5">
     <e:exam-versions>
@@ -32,6 +61,26 @@ const examXml = `<e:exam xmlns:e="http://ylioppilastutkinto.fi/exam.xsd" xmlns="
                 <br/>
             </e:question-instruction>
             <e:text-answer type="integer" max-score="1"/>
+        </e:question>
+    </e:section>
+</e:exam>`
+
+const richTextExamXml = `<e:exam xmlns:e="http://ylioppilastutkinto.fi/exam.xsd" xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ylioppilastutkinto.fi/exam.xsd https://abitti.net/schema/exam.xsd" exam-schema-version="0.5" exam-lang="fi-FI">
+    <e:exam-versions>
+        <e:exam-version lang="fi-FI"/>
+    </e:exam-versions>
+    <e:exam-title>Exam</e:exam-title>
+    <e:exam-instruction/>
+    <e:table-of-contents/>
+    <e:section>
+        <e:section-title>Section</e:section-title>
+        <e:section-instruction/>
+        <e:question display-number="1" question-id="1" max-score="6">
+            <e:question-title>Tekstitehtävä</e:question-title>
+            <e:question-instruction>
+                <br/>
+            </e:question-instruction>
+            <e:text-answer type="rich-text" max-score="6" question-id="2" display-number="1"/>
         </e:question>
     </e:section>
 </e:exam>`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "redux": "^5.0.1",
     "redux-saga": "^1.5.1",
     "redux-saga-test-plan": "^4.0.6",
-    "rich-text-editor": "^8.11.2",
+    "rich-text-editor": "^8.12.0",
     "sanitize-html": "^2.17.6",
     "typesafe-actions": "^5.1.0",
     "utility-types": "^3.10.0",

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -34,7 +34,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router5": "^8.0.1",
-    "rich-text-editor": "^8.11.2",
+    "rich-text-editor": "^8.12.0",
     "router5": "^8.0.1",
     "router5-plugin-browser": "^8.0.1",
     "tmp-promise": "^3.0.2",


### PR DESCRIPTION
**bugi: rich-text-editorissa undo/redo peruu/palauttaa yhden merkin kerrallaan, eikä RTE:n määrittämä kokonaisuus kerrallaan (= 500ms:n debouncen määrittämä palautuspiste).**

Editorin vastaushistoria on debouncattu 500 ms:iin, joten yhtenäisen kirjoituspurskeen pitäisi peruuntua ja palautua yhtenä askeleena. Näin ei kuitenkaan tapahtunut: jokainen muutos dispatchataan redux-storeen, mikä renderöi editorin uudelleen joka näppäinpainalluksella, ja rich-text-editor rakensi debouncensa uudelleen joka renderöinnillä. Niinpä jokaisesta näppäinpainalluksesta tuli oma historiamerkintänsä ja undo siirtyi merkki kerrallaan.

Tässä video nykyisestä, virheellsestä toiminnasta: undo poistaa yhden merkin kerrallaan:

https://github.com/user-attachments/assets/c0d90cc3-0c62-4ab8-b406-d85f613f9f6e



👇 Tässä videolla näkyy kuinka undo toimii oikein. Kutakin kirjainta painellaa tiheästi, ja sitten pidetään vähintään 500ms:n tauko (RTE:n debounce). Undo poistaa aina kaikki samat kirjaimet kerrallaan. 

https://github.com/user-attachments/assets/e2afe986-9bee-4c55-b5bb-b58c2e6aac1f

